### PR TITLE
Update openapi.yaml

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,56 +1,68 @@
-# This is **ZelFlux** API documentation
-
 openapi: 3.0.0
 info:
-  version: '0.0.3' # Your API version
-  # It can be any string but it is better to use semantic versioning: http://semver.org/
-  # Warning: OpenAPI require version to be string, but without quotation YAML can recognize it as number.
-  
-  title: ZelFlux # Replace with your API title
-  # Keep it simple. Don't add "API" or version at the end of the string.
-
+  version: 0.0.3
+  title: ZelFlux
   contact:
-    email: tadeas.kmenta@zel.cash # [Optional] Replace with your contact email
-    url: 'https://zelcash.github.io/zelfluxdocs/' # [Optional] Replace with link to your contact form
+    email: tadeas.kmenta@zel.cash
+    url: 'https://zelcash.github.io/zelfluxdocs/'
   license:
     name: GNU AGPLv3
     url: 'https://www.gnu.org/licenses/agpl-3.0.en.html'
   x-logo:
     url: 'https://raw.githubusercontent.com/zelcash/zelfluxdocs/master/zelflux.png'
-  
-  # Describe your API here, you can use GFM (https://guides.github.com/features/mastering-markdown) here
-  description: |
+  description: >
     This is an API documentation of calls available to be made to any ZelFlux
-    ZelFlux is completely open source and we encourage everyone to feel free and contribute :)
+
+    ZelFlux is completely open source and we encourage everyone to feel free and
+    contribute :)
+
     # Introduction
-    ZelFlux posseses with 4 tier hiearchy level API. 
-    * Public API level - available without any permission, does not require signing
-    * User API level - user level permission, requires signing
-    * ZelTeam API level - ZelTeam level permission (an appointed Zel Team member has access to those API calls), requires signing
-    * Admin API level - Admin level permission, requires signing. ZelNode owner.
-    
-    Most calls are available via GET request with some that may require large amount of data via POST request. 
-    Websocket is currently used only for simplifying login operations and for internal ZelFlux communication
-  
+
+    ZelFlux possesses with 4 tier hiearchy level API. 
+
+    * **Public** API level - Available without any permission, does not require
+    signing.
+
+    * **User** API level - User level permission, requires signing.
+
+    * **ZelTeam** API level - ZelTeam level permission (an appointed Zel Team
+    member has access to those API calls), requires signing.
+
+    * **Admin** API level - Admin level permission, requires signing. ZelNode
+    owner.
+
+
+    Most calls are available via GET request with some that may require large
+    amount of data via POST request. 
+
+    Websocket is currently used only for simplifying login operations and for
+    internal ZelFlux communication.
 externalDocs:
   description: ZelFlux
   url: 'https://github.com/zelcash/zelflux'
-
-# A list of tags used by the specification with additional metadata.
-# The order of the tags can be used to reflect on their order by the parsing tools.
 tags:
   - name: Authentication
-    description: Calls that are neccessary to be made for correct signing into ZelFlux and obtaining zelauth header.
+    description: >-
+      Calls that are neccessary to be made for correct signing into ZelFlux and
+      obtaining zelauth header.
   - name: ZelID
-    description: Calls that interact with ZelID and login/authentication management of ZelFlux
+    description: >-
+      Calls that interact with ZelID and login/authentication management of
+      ZelFlux
   - name: ZelFlux
     description: Calls that interact with ZelFlux and its network
   - name: ZelCash
     description: Calls that interact with locally running ZelCash daemon
+  - name: ZelBench
+    description: Calls that interact with locally running ZelBench daemon
   - name: ZelNode
     description: Calls that interact with local ZelNode and its network
   - name: ZelApps
-    description: Calls that interact with ZelApps fascilitated by local ZelFlux and ZelNode network
+    description: >-
+      Calls that interact with ZelApps fascilitated by local ZelFlux and ZelNode
+      network
+  - name: Explorer
+    description: Calls that interact with locally running explorer
 servers:
   - url: 'https://basic2.thecorporation.club'
   - url: 'http://157.230.249.150:16127'
@@ -61,16 +73,17 @@ servers:
   - url: 'http://194.182.83.182:16127'
   - url: 'https://157.230.249.150:16128'
   - url: 'http://127.0.0.1:16127'
-# Holds the relative paths to the individual endpoints. The path is appended to the
-# basePath in order to construct the full URL. 
 paths:
-  '/zelid/loginphrase': # path parameter in curly braces
-    get: # documentation for GET operation for this path
+  /zelid/loginphrase:
+    get:
       tags:
         - Authentication
         - ZelID
       summary: Obtain login phrase
-      description: Obtain valid Login Phrase for signing into ZelFlux. Login Phrase is at least 40 characters, first 13 characters is server timestamp and is valid for 15 minutes. PUBLIC
+      description: >-
+        Obtain valid Login Phrase for signing into ZelFlux. Login Phrase is at
+        least 40 characters, first 13 characters is server timestamp and is
+        valid for 15 minutes. **PUBLIC**
       operationId: loginPhrase
       responses:
         '200':
@@ -80,24 +93,52 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
-                    type: string
-                    description: status
-                    enum: [success, error]
+                  status:
+                    $ref: '#/components/schemas/status'
                   data:
                     type: string
                     description: loginphrase
               example:
                 status: success
                 data: 1574994809615gj4ct52kzz695twl0l27np0ivkmvu2ow4lbtpwk2nvf2k
-  '/zelid/verifylogin': # path parameter in curly braces
-    post: # documentation for POST operation for this path
+  /zelid/emergencyphrase:
+    get:
+      tags:
+        - ZelID
+      summary: Obtain emergency login phrase
+      description: Obtain emergency Login Phrase for signing into ZelFlux. **PUBLIC**
+      operationId: emergencyLoginPhrase
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: loginphrase
+              example:
+                status: success
+                data: 1587939091067l06vdyv5wtl80q5aj0npi3vyyig869ogf7o7jxfpu68r
+  /zelid/verifylogin:
+    post:
       tags:
         - Authentication
         - ZelID
       summary: Login into ZelFlux
-      description: Login into ZelFlux by submitting correct ZelID, login phrase and signature. In case of success status response, we can use supplied data (zelid, loginPhrase, signature) as zelauth header as part of api calls that require a user to be logged in.
-        Additionally it is possible to listen for a response on websocket ws://{ZelNode_IP}:16127/ws/zelid/{loginPhrase}. PUBLIC
+      description: >-
+        Login into ZelFlux by submitting correct ZelID, login phrase and
+        signature. Note that to get the signature of the signed message you
+        would need to do the signing on Zelcore or your BTC wallet. If success
+        status response is returned, we can use the supplied data(zelid,
+        loginPhrase, signature) as zelauth header as part of api calls that
+        require a user to be logged in. Additionally it is possible to listen
+        for a response on websocket.
+        ws://{ZelNode_IP}:16127/ws/zelid/{loginPhrase}. **PUBLIC**
       operationId: verifyLogin
       responses:
         '200':
@@ -107,10 +148,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     type: string
                     description: status
-                    enum: [success, error]
+                    enum:
+                      - success
+                      - error
                   data:
                     type: object
                     properties:
@@ -129,16 +172,19 @@ paths:
                       privilege:
                         type: string
                         description: granted ZelFlux privilege
-                        enum: [user, zelteam, admin]
+                        enum:
+                          - user
+                          - zelteam
+                          - admin
               example:
                 status: success
                 data:
                   message: Successfully logged in
                   zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
                   loginPhrase: 1575012988077darschvve5ag82g8e8sgeij4sn61842ya7ovxi9r3kba
-                  signature: IAMZBB0p8aQ6A0Zt8uUKFLdWvPJlBypuczhaM6/R+s5bI72NQs/TPF1KYywvJlumMZyvLmk7JelDwaQbfTjqtSs=
+                  signature: >-
+                    IAMZBB0p8aQ6A0Zt8uUKFLdWvPJlBypuczhaM6/R+s5bI72NQs/TPF1KYywvJlumMZyvLmk7JelDwaQbfTjqtSs=
                   privilage: admin
-      # request body documentation
       requestBody:
         content:
           text/plain:
@@ -146,14 +192,15 @@ paths:
               $ref: '#/components/schemas/ZelIDLogin'
         description: ZelID login object
         required: true
-  '/zelid/loggedsessions': # path parameter in curly braces
-    get: # documentation for GET operation for this path
+  /zelid/loggedsessions:
+    get:
       tags:
         - ZelID
-      summary: Obtain all logged sessions of ZelID. 
-      description: Gets all currently active logged sessions in ZelFlux tied to given ZelID. USER
+      summary: Obtain all logged sessions of ZelID.
+      description: >-
+        Gets all currently active logged sessions in ZelFlux tied to given
+        ZelID. **USER**
       operationId: loggedSessions
-      # security schemas applied to this operation
       security:
         - ZelID: []
       responses:
@@ -164,44 +211,43 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
-                    type: string
-                    description: status
-                    enum: [success, error]
+                  status:
+                    $ref: '#/components/schemas/status'
                   data:
-                   type: array
-                   items: 
-                     type: object
-                     properties:
-                       zelid:
-                         type: string
-                         description: associated ZelID
-                       loginPhrase:
-                         type: string
-                         description: login phrase used for session
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        zelid:
+                          type: string
+                          description: associated ZelID
+                        loginPhrase:
+                          type: string
+                          description: login phrase used for session
               example:
                 status: success
                 data:
-                - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
-                  loginPhrase: 1566749385160npvtiku0z7yqsxgenyvzfmfrz7pyxrxvflv3sfztbc
-                - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
-                  loginPhrase: 1566822581693fuuo3oi0sqdvab9h8baavc0kdawxvbwjgdbjsy5tk739m
-                - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
-                  loginPhrase: 1566970790344nhd5tjwyphq4l1azf5o64axfz75b8892poo853ivbfc
-                - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
-                  loginPhrase: 15673514189266fzehz9q1ujvw4fg5lsko9q6qrfji3iwfg9hkblx5dpm
-                - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
-                  loginPhrase: 1575011828315mzqenqvi9ixaq0yr34g8jtvwgcs3d33cf1ies0myd
-                - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
-                  loginPhrase: 1575012988077darschvve5ag82g8e8sgeij4sn61842ya7ovxi9r3kba
-  '/zelid/logoutcurrentsession': # path parameter in curly braces
-    get: # documentation for GET operation for this path
+                  - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
+                    loginPhrase: 1566749385160npvtiku0z7yqsxgenyvzfmfrz7pyxrxvflv3sfztbc
+                  - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
+                    loginPhrase: 1566822581693fuuo3oi0sqdvab9h8baavc0kdawxvbwjgdbjsy5tk739m
+                  - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
+                    loginPhrase: 1566970790344nhd5tjwyphq4l1azf5o64axfz75b8892poo853ivbfc
+                  - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
+                    loginPhrase: 15673514189266fzehz9q1ujvw4fg5lsko9q6qrfji3iwfg9hkblx5dpm
+                  - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
+                    loginPhrase: 1575011828315mzqenqvi9ixaq0yr34g8jtvwgcs3d33cf1ies0myd
+                  - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
+                    loginPhrase: 1575012988077darschvve5ag82g8e8sgeij4sn61842ya7ovxi9r3kba
+  /zelid/logoutcurrentsession:
+    get:
       tags:
         - ZelID
       summary: Logs out current session
-      description: This call logs out currently logged session which is determined by the supplied authentication header. USER
+      description: >-
+        This call logs out currently logged session which is determined by the
+        supplied authentication header. **USER**
       operationId: logoutCurrentSession
-      # security schemas applied to this operation
       security:
         - ZelID: []
       responses:
@@ -212,28 +258,23 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
-                    type: string
-                    description: status
-                    enum: [success, error]
+                  status:
+                    $ref: '#/components/schemas/status'
                   data:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        description: explanation of status
+                    $ref: '#/components/schemas/statusmessage'
               example:
                 status: success
                 data:
                   message: Successfully logged out
-  '/zelid/logoutallsessions': # path parameter in curly braces
-    get: # documentation for GET operation for this path
+  /zelid/logoutallsessions:
+    get:
       tags:
         - ZelID
       summary: Logs out all sessions
-      description: This call logs out all logged sessions which are determined by the supplied authentication header. USER
+      description: >-
+        This call logs out all logged sessions which are determined by the
+        supplied authentication header. **USER**
       operationId: logoutAllSession
-      # security schemas applied to this operation
       security:
         - ZelID: []
       responses:
@@ -244,26 +285,23 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        description: explanation of status
+                    $ref: '#/components/schemas/statusmessage'
               example:
                 status: success
                 data:
                   message: Successfully logged out all sessions
-  '/zelid/loggedusers': # path parameter in curly braces
-    get: # documentation for GET operation for this path
+  /zelid/loggedusers:
+    get:
       tags:
         - ZelID
       summary: Gets information about logged users
-      description: This call gets basic infromation about currently logged sessions of all users. ADMIN
+      description: >-
+        This call gets basic infromation about currently logged sessions of all
+        users. **ADMIN**
       operationId: loggedUsers
-      # security schemas applied to this operation
       security:
         - ZelID: []
       responses:
@@ -274,32 +312,35 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
-                   type: array
-                   items: 
-                     type: object
-                     properties:
-                       zelid:
-                         type: string
-                         description: users ZelID
-                       loginPhrase:
-                         type: string
-                         description: login phrase used for session
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        zelid:
+                          type: string
+                          description: users ZelID
+                        loginPhrase:
+                          type: string
+                          description: login phrase used for session
               example:
                 status: success
                 data:
-                - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
-                  loginPhrase: 1566749385160npvtiku0z7yqsxgenyvzfmfrz7pyxrxvflv3sfztbc
-                - zelid: 1E1NSwDHtvCziYP4CtgiDMcgvgZL64PhkR
-                  loginPhrase: 1575805361736fdk6ak6yn5lgiuebz1oumh9z8rhyw0kf744f1sk2yd43
-  '/zelid/activeloginphrases':
+                  - zelid: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
+                    loginPhrase: 1566749385160npvtiku0z7yqsxgenyvzfmfrz7pyxrxvflv3sfztbc
+                  - zelid: 1E1NSwDHtvCziYP4CtgiDMcgvgZL64PhkR
+                    loginPhrase: 1575805361736fdk6ak6yn5lgiuebz1oumh9z8rhyw0kf744f1sk2yd43
+  /zelid/activeloginphrases:
     get:
       tags:
         - ZelID
       summary: Lists active login phrases
-      description: This call gets a list of login phrases that are currently active (were generated less than 15 minutes ago) - phrases that have been used recently and phrases that can be used to log in.. ADMIN
+      description: >-
+        This call gets a list of login phrases that are currently active (were
+        generated less than 15 minutes ago) - phrases that have been used
+        recently and phrases that can be used to log in.. **ADMIN**
       operationId: activeLoginPhrases
       security:
         - ZelID: []
@@ -311,11 +352,11 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
                     type: array
-                    items: 
+                    items:
                       type: object
                       properties:
                         loginPhrase:
@@ -326,24 +367,27 @@ paths:
                           description: timestamp of loginPhrase creation in server time.
                         expireAt:
                           type: string
-                          description: expiration timestamp of loginPhrase. After this time, the loginPhrase cannot be used anymore.
+                          description: >-
+                            expiration timestamp of loginPhrase. After this
+                            time, the loginPhrase cannot be used anymore.
               example:
                 status: success
                 data:
-                - loginPhrase: 1575865221315yqilps02mx0e1tmf5ymtcry8mbzk4u3k3v17tdsxif6
-                  createdAt: '2019-12-09T04:20:21.315Z'
-                  expireAt: '2019-12-09T04:35:21.315Z'
-                - loginPhrase: 1575865221315yqilps02mx0e1tmf5ymtcry8mbzk4u3k3v17tdsxif6
-                  createdAt: '2019-12-09T04:20:21.315Z'
-                  expireAt: '2019-12-09T04:35:21.315Z'
-  '/zelid/logoutallusers': # path parameter in curly braces
-    get: # documentation for GET operation for this path
+                  - loginPhrase: 1575865221315yqilps02mx0e1tmf5ymtcry8mbzk4u3k3v17tdsxif6
+                    createdAt: '2019-12-09T04:20:21.315Z'
+                    expireAt: '2019-12-09T04:35:21.315Z'
+                  - loginPhrase: 1575865221315yqilps02mx0e1tmf5ymtcry8mbzk4u3k3v17tdsxif6
+                    createdAt: '2019-12-09T04:20:21.315Z'
+                    expireAt: '2019-12-09T04:35:21.315Z'
+  /zelid/logoutallusers:
+    get:
       tags:
         - ZelID
       summary: Logs out all users
-      description: This call logs out all logged users (including zelteam, admins). ADMIN
+      description: >-
+        This call logs out all logged users (including zelteam, admins).
+        **ADMIN**
       operationId: logoutAllUsers
-      # security schemas applied to this operation
       security:
         - ZelID: []
       responses:
@@ -354,19 +398,15 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        description: explanation of status
+                    $ref: '#/components/schemas/statusmessage'
               example:
                 status: success
                 data:
                   message: Successfully logged out all users
-  '/zelid/logoutspecificsession':
+  /zelid/logoutspecificsession:
     post:
       tags:
         - Authentication
@@ -374,7 +414,11 @@ paths:
       summary: Logs out a specific session
       security:
         - ZelID: []
-      description: Logs out a specific session. Requires the knowledge of a session loginPhrase and so users level is sufficient and user cannot logout another user as he does not know the loginPhrase. Admin can logout any specific session. USER
+      description: >-
+        Logs out a specific session. Requires the knowledge of a session
+        loginPhrase and so users level is sufficient and user cannot logout
+        another user as he does not know the loginPhrase. Admin can logout any
+        specific session. **USER**
       operationId: logoutSpecificSession
       responses:
         '200':
@@ -384,16 +428,10 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
-                    type: string
-                    description: status
-                    enum: [success, error]
+                  status:
+                    $ref: '#/components/schemas/status'
                   data:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        description: explanation of status
+                    $ref: '#/components/schemas/statusmessage'
               example:
                 status: success
                 data:
@@ -411,12 +449,14 @@ paths:
                   example: 1574991374806spbcvsuwerl52tppx9dw5khuz8rew13mkq86gg8r2c
         description: Object containing loginPhrase
         required: true
-  '/zelnode/startzelcash':
+  /zelnode/startzelcash:
     get:
       tags:
         - ZelNode
       summary: Starts ZelNodes ZelCash daemon
-      description: Tries to start ZelCash daemon running on the ZelNode the call is run against without any extra parameters. ADMIN
+      description: >-
+        Tries to start ZelCash daemon running on the ZelNode the call is run
+        against without any extra parameters. **ADMIN**
       operationId: startZelCash
       security:
         - ZelID: []
@@ -428,24 +468,23 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        description: explanation of status
+                    $ref: '#/components/schemas/statusmessage'
               example:
                 status: success
                 data:
                   message: ZelCash successfully started
-  '/zelnode/restartzelcash':
+  /zelnode/restartzelcash:
     get:
       tags:
         - ZelNode
       summary: Restarts ZelNodes ZelCash daemon
-      description: Tries to restart ZelCash daemon running on the ZelNode the call is run against. ZelCash daemon is firstly stopped and then started without any extra parameters. ADMIN
+      description: >-
+        Tries to restart ZelCash daemon running on the ZelNode the call is run
+        against. ZelCash daemon is firstly stopped and then started without any
+        extra parameters. **ADMIN**
       operationId: restartZelCash
       security:
         - ZelID: []
@@ -457,24 +496,23 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        description: explanation of status
+                    $ref: '#/components/schemas/statusmessage'
               example:
                 status: success
                 data:
                   message: ZelCash successfully restarted
-  '/zelnode/reindexzelcash':
+  /zelnode/reindexzelcash:
     get:
       tags:
         - ZelNode
       summary: Reindexes ZelNodes ZelCash daemon
-      description: Tries to reindex ZelCash daemon running on the ZelNode the call is run against. ZelCash daemon is firstly stopped and then started with reindex flag. ADMIN
+      description: >-
+        Tries to reindex ZelCash daemon running on the ZelNode the call is run
+        against. ZelCash daemon is firstly stopped and then started with reindex
+        flag. **ADMIN**
       operationId: reindexZelCash
       security:
         - ZelID: []
@@ -486,24 +524,23 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        description: explanation of status
+                    $ref: '#/components/schemas/statusmessage'
               example:
                 status: success
                 data:
                   message: ZelCash successfully reindexing
-  '/zelnode/updatezelflux':
+  /zelnode/updatezelflux:
     get:
       tags:
         - ZelNode
       summary: Updates ZelFlux to the latest version
-      description: Updates ZelFlux to the latest version available according to github master branch. ZelFlux will restart its services after the update. ZELTEAM
+      description: >-
+        Updates ZelFlux to the latest version available according to github
+        master branch. ZelFlux will restart its services after the update.
+        **ZELTEAM** **ADMIN**
       operationId: updateZelFlux
       security:
         - ZelID: []
@@ -515,24 +552,52 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        description: explanation of status
+                    $ref: '#/components/schemas/statusmessage'
               example:
                 status: success
                 data:
-                  message: ZelFlux successfully updated
-  '/zelnode/rebuildzelfront':
+                  message: ZelFlux successfully updating
+  /zelnode/hardupdatezelflux:
+    get:
+      tags:
+        - ZelNode
+      summary: Perform hard update to the latest version
+      description: >-
+        Hard updates to latest version by removing node_modules and
+        package-lock.json before executing git reset --hard and git pull. This
+        may resolve any issues that may arise from ZelFlux not being able to
+        update using the `GET /zelnode/updatezelflux` call. ZelFlux will restart
+        its services after the update. **ZELTEAM** **ADMIN**
+      operationId: hardUpdateZelFlux
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: ZelFlux successfully updating
+  /zelnode/rebuildzelfront:
     get:
       tags:
         - ZelNode
       summary: Rebuild UI - ZelFront of ZelFlux
-      description: Rebuilds ZelFront part of ZelFlux. May help resolving frontend issues. ZELTEAM
+      description: >-
+        Rebuilds ZelFront part of ZelFlux. May help resolving frontend issues.
+        **ZELTEAM** **ADMIN**
       operationId: rebuildZelFront
       security:
         - ZelID: []
@@ -544,24 +609,23 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        description: explanation of status
+                    $ref: '#/components/schemas/statusmessage'
               example:
                 status: success
                 data:
                   message: ZelFlux successfully rebuilt
-  '/zelnode/updatezelcash':
+  /zelnode/updatezelcash:
     get:
       tags:
         - ZelNode
       summary: Updates ZelCash daemon
-      description: Updates the ZelCash daemon of ZelNode to the latest available version according to official Zel APT repository. ZelCash daemon is restarted with no extra parameters during this update. ZELTEAM
+      description: >-
+        Updates the ZelCash daemon of ZelNode to the latest available version
+        according to official Zel APT repository. ZelCash daemon is restarted
+        with no extra parameters during this update. **ZELTEAM** **ADMIN**
       operationId: updateZelCash
       security:
         - ZelID: []
@@ -573,24 +637,402 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
-                    type: object
-                    properties:
-                      message:
-                        type: string
-                        description: explanation of status
+                    $ref: '#/components/schemas/statusmessage'
               example:
                 status: success
                 data:
                   message: ZelCash successfully updated
-  '/zelflux/version':
+  /zelnode/updatezelbench:
+    get:
+      tags:
+        - ZelNode
+      summary: Updates Zelbench daemon
+      description: >-
+        Updates the ZelBench daemon of ZelNode to the latest available version
+        according to official Zel APT repository. ZelBench daemon is restarted
+        with no extra parameters during this update. **ZELTEAM** **ADMIN**
+      operationId: updateZelBench
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: ZelBench successfully updated
+  /zelnode/zelcashdebug:
+    get:
+      tags:
+        - ZelNode
+      summary: Returns with the zelcash debug log
+      description: >-
+        Returns with the debug log located in ZelCash data directory.
+        **ZELTEAM** **ADMIN**
+      operationId: zelcashDebug
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Debug log
+              example: >-
+                2020-05-09 11:27:30 Zelcash version v4.0.1-32bd16d-dirty
+                (2020-03-20 19:05:39 +0000) 2020-05-09 11:27:30 AppInit2:
+                parameter interaction: -externalip set -> setting -discover=0
+                2020-05-09 11:27:30 Using BerkeleyDB version Berkeley DB 6.2.23:
+                (March 28, 2016) 2020-05-09 11:27:30 Default data directory
+                /home/zel/.zelcash 2020-05-09 11:27:30 Using data directory
+                /home/zel/.zelcash/ 2020-05-09 11:27:30 Using config file
+                /home/zel/.zelcash/zelcash.conf 2020-05-09 11:27:30 Using at
+                most 256 connections (1024 file descriptors available)
+                2020-05-09 11:27:30 Using 2 threads for script verification
+                2020-05-09 11:27:30 scheduler thread start 2020-05-09 11:27:30
+                Loading Sapling (Spend) parameters from
+                /home/zel/.zcash-params/sapling-spend.params 2020-05-09 11:27:30
+                Loading Sapling (Output) parameters from
+                /home/zel/.zcash-params/sapling-output.params 2020-05-09
+                11:27:30 Loading Sapling (Sprout Groth16) parameters from
+                /home/zel/.zcash-params/sprout-groth16.params 2020-05-09
+                11:27:34 Loaded Sapling parameters in 4.129045s seconds.
+                2020-05-09 11:27:34 Binding RPC on address 0.0.0.0 port 16124
+                failed. 2020-05-09 11:27:34 HTTP: creating work queue of depth
+                16 2020-05-09 11:27:34 HTTP: starting 4 worker threads
+                2020-05-09 11:27:34 Using wallet wallet.dat 2020-05-09 11:27:34
+                init message: Verifying wallet...
+  /zelnode/zelbenchdebug:
+    get:
+      tags:
+        - ZelNode
+      summary: Returns with the ZelBench debug log
+      description: >-
+        Returns with the debug log located in zelbenchmark directory.
+        **ZELTEAM** **ADMIN**
+      operationId: zelbenchDebug
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Debug log
+              example: >-
+                2020-05-13 16:59:02 Benchmark version v1.0.0-beta1-53e0ea2-dirty
+                (2020-04-25 13:03:38 +0800) 2020-05-13 16:59:02 Using OpenSSL
+                version OpenSSL 1.1.1a  20 Nov 2018 2020-05-13 16:59:02 HTTP:
+                creating work queue of depth 16 2020-05-13 16:59:02 HTTP:
+                starting 4 worker threads 2020-05-13 16:59:02 Bound to
+                [::]:16225 2020-05-13 16:59:02 Bound to 0.0.0.0:16225 2020-05-13
+                16:59:02 init message: Done loading 2020-05-13 16:59:02 Starting
+                Zelnodes Benchmarking Thread 2020-05-13 16:59:03 Path:
+                /home/zel/zelflux/ZelBack 2020-05-13 16:59:03 ---ZelFlux usage:
+                0.23012 2020-05-13 16:59:03 ---package evaluator system setup
+                starting 2020-05-13 16:59:03 ---package evaluator already
+                installed 2020-05-13 16:59:03 ---package evaluator found
+                version: 1.0.11 2020-05-13 16:59:03 ---package evaluator system
+                setup completed 2020-05-13 16:59:03 ---Starting computer specs
+                test 2020-05-13 16:59:08 ---Found cores: 2 2020-05-13 16:59:08
+                ---Found ram: 3.8 2020-05-13 16:59:08 ---Found HDD: 38.200001 G
+                2020-05-13 16:59:08 ---Found HDD: 12.000000 G 2020-05-13
+                16:59:08 ---Found DD_WRITE: 675.628 2020-05-13 16:59:08
+                ---Finished computer specs test 2020-05-13 16:59:08 ---Starting
+                package evaluator test 2020-05-13 16:59:29 ---Found eps v1:
+                157.185 2020-05-13 16:59:29 ---Finished package evaluator test
+  /zelnode/zelfluxerrorlog:
+    get:
+      tags:
+        - ZelNode
+      summary: Returns with the ZelFlux error log
+      description: >-
+        Returns with the error log located in zelflux directory. **ZELTEAM**
+        **ADMIN**
+      operationId: zelfluxErrorLog
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Error log
+              example: >-
+                2020-05-13T11:43:35.223Z          {}
+                2020-05-13T16:58:20.492Z         
+                {"code":"ECONNREFUSED","name":"Error","message":"connect
+                ECONNREFUSED 127.0.0.1:16124"} 2020-05-13T16:58:20.494Z         
+                {} 2020-05-13T16:58:29.181Z         
+                {"code":"ECONNREFUSED","name":"Error","message":"connect
+                ECONNREFUSED 127.0.0.1:16124"} 2020-05-13T16:59:03.686Z         
+                {"code":-28,"name":"Error","message":"Loading zelnode payment
+                cache..."} 2020-05-13T20:51:36.484Z          {}
+                2020-05-14T07:15:38.355Z          {}
+                2020-05-14T12:18:38.695Z          {}
+                2020-05-14T13:30:35.112Z         
+                {"code":"ECONNREFUSED","name":"Error","message":"connect
+                ECONNREFUSED 127.0.0.1:16124"} 2020-05-14T13:30:35.114Z         
+                {} 2020-05-14T13:30:38.782Z          {}
+                2020-05-14T13:31:09.309Z         
+                {"code":-28,"name":"Error","message":"Loading zelnode payment
+                cache..."} 2020-05-14T13:37:30.205Z         
+                {"code":"ECONNREFUSED","name":"Error","message":"connect
+                ECONNREFUSED 127.0.0.1:16124"} 2020-05-14T13:38:10.519Z         
+                {"code":-28,"name":"Error","message":"Loading zelnode payment
+                cache..."} 2020-05-14T13:58:08.810Z          {}
+                2020-05-14T14:49:30.295Z         
+                {"code":"ECONNREFUSED","name":"Error","message":"connect
+                ECONNREFUSED 127.0.0.1:16124"} 2020-05-14T14:49:32.669Z         
+                {"code":"ECONNREFUSED","name":"Error","message":"connect
+                ECONNREFUSED 127.0.0.1:16124"} 2020-05-14T14:49:32.672Z         
+                {} 2020-05-14T14:50:10.807Z         
+                {"code":-28,"name":"Error","message":"Loading zelnode payment
+                cache..."} 2020-05-14T16:19:39.197Z          {}
+  /zelflux/info:
+    get:
+      tags:
+        - ZelFlux
+      summary: Combined info
+      description: Combined info of statuses. **PUBLIC**
+      operationId: getZelFluxInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      zelcash:
+                        type: object
+                        properties:
+                          info:
+                            $ref: '#/components/schemas/zelcashgetinfo'
+                      zelnode:
+                        type: object
+                        properties:
+                          status:
+                            $ref: '#/components/schemas/zelnodestatus'
+                      zelbench:
+                        type: object
+                        properties:
+                          info:
+                            $ref: '#/components/schemas/benchinfo'
+                          status:
+                            $ref: '#/components/schemas/benchstatus'
+                          bench:
+                            $ref: '#/components/schemas/getbenchmarks'
+                      zelflux:
+                        type: object
+                        properties:
+                          version:
+                            type: string
+                            description: Version number
+                          ip:
+                            type: string
+                            description: Server's IP address
+                          zelid:
+                            type: string
+                            description: Admin's ZelID
+                          timezone:
+                            type: string
+                            description: Server's timezone
+                          dos:
+                            type: object
+                            properties:
+                              dosState:
+                                type: integer
+                                description: Numbers 1-10 in which state it's in 
+                              dosMessage:
+                                type: string
+                                description: Status message or Null if no message
+                      zelapps:
+                        type: object
+                        properties:
+                          fluxusage:
+                            type: string
+                            description: Amount of CPU usage
+                          runningapps:
+                            $ref: '#/components/schemas/containerinfo'
+                          resources:
+                            $ref: '#/components/schemas/zelappsresources'
+              example:
+                status: success
+                data:
+                  zelcash:
+                    info:
+                      version: 4000150
+                      protocolversion: 170016
+                      walletversion: 60000
+                      balance: 0
+                      blocks: 590441
+                      timeoffset: 0
+                      connections: 27
+                      proxy: ''
+                      difficulty: 2629.292064176152
+                      testnet: false
+                      keypoololdest: 1588335749
+                      keypoolsize: 101
+                      paytxfee: 0
+                      relayfee: 0.000001
+                      errors: ''
+                  zelnode:
+                    status:
+                      status: CONFIRMED
+                      collateral: >-
+                        COutPoint(d51c017cb61557137dc31e1fd630df34072555c8c659cd45af42cf33b5e2227e,
+                        0)
+                      txhash: >-
+                        d51c017cb61557137dc31e1fd630df34072555c8c659cd45af42cf33b5e2227e
+                      outidx: '0'
+                      ip: 167.86.81.87
+                      network: ipv4
+                      added_height: 587002
+                      confirmed_height: 587005
+                      last_confirmed_height: 590486
+                      last_paid_height: 590359
+                      tier: SUPER
+                      payment_address: t1SiLvqFSjz2VJ5oMzv92yk1EeekSjexc6U
+                      pubkey: >-
+                        049a8a290ecb831f7d23b82c3d9fc9fdd029e5c7b0832044480b96d36b785a8c680c4fcc832c885b6f376495ee884ae1137fc156f7102efbddb9900d45fe1787ff
+                      activesince: '1588098076'
+                      lastpaid: '1588504103'
+                  zelbench:
+                    info:
+                      version: 1.3.1
+                      rpcport: 16224
+                    status:
+                      status: online
+                      benchmarking: SUPER
+                      zelback: connected
+                    bench:
+                      ipaddress: 167.86.81.87
+                      status: SUPER
+                      time: 1588523682
+                      cores: 4
+                      ram: 7.800000190734863
+                      ssd: 0
+                      hdd: 200.0308074951172
+                      ddwrite: 308.4692077636719
+                      eps: 220.1355895996094
+                  zelflux:
+                    version: 0.58.2
+                    ip: 167.86.81.87
+                    zelid: 1K6nyw2VjV6jEN1f1CkbKn9htWnYkQabbR
+                    timezone: Europe/Berlin
+                    dos:
+                      dosState: 0
+                      dosMessage: null
+                  zelapps:
+                    fluxusage: '2.84624023'
+                    runningapps:
+                      - Id: >-
+                          3502b57e324ce8a278700e5bb700c60a5d3256f45d22a07d53c970b41fceec6e
+                        Names:
+                          - /zelFoldingAtHome
+                        Image: 'yurinnick/folding-at-home:latest'
+                        ImageID: >-
+                          sha256:ec31bf7fa749ec82c38191a83a325fa12689bfd3f4c05a0527e603c9aa9475f2
+                        Command: >-
+                          /opt/fahclient/entrypoint.sh --allow 0/0 --web-allow
+                          0/0
+                        Created: 1587401033
+                        Ports:
+                          - PrivatePort: 36330
+                            Type: tcp
+                          - IP: 0.0.0.0
+                            PrivatePort: 7396
+                            PublicPort: 30000
+                            Type: tcp
+                        Labels: {}
+                        State: running
+                        Status: Up 9 days
+                        HostConfig:
+                          NetworkMode: zelfluxDockerNetwork
+                        NetworkSettings:
+                          Networks:
+                            zelfluxDockerNetwork:
+                              IPAMConfig: null
+                              Links: null
+                              Aliases: null
+                              NetworkID: >-
+                                7c9c2fb1680cecdbd121668453894f3ddad4ce254aac2293dd3fbbc48968b2c0
+                              EndpointID: >-
+                                7e598a3022547ad3db5c8fae8ce411ddd031013700904059e1589812bf1596cc
+                              Gateway: 172.16.0.1
+                              IPAddress: 172.16.0.2
+                              IPPrefixLen: 16
+                              IPv6Gateway: ''
+                              GlobalIPv6Address: ''
+                              GlobalIPv6PrefixLen: 0
+                              MacAddress: '02:23:ac:10:00:05'
+                              DriverOpts: null
+                        Mounts:
+                          - Type: bind
+                            Source: /home/zel/zelflux/ZelApps/zelFoldingAtHome
+                            Destination: /config
+                            Mode: ''
+                            RW: true
+                            Propagation: rprivate
+                    resources:
+                      zelAppsCpusLocked: 1
+                      zelAppsRamLocked: 1000
+                      zelAppsHddLocked: 15
+  /zelflux/timezone:
+    get:
+      tags:
+        - ZelFlux
+      summary: ZelFlux timezone
+      description: This will return with the timezone of the server. **PUBLIC**
+      operationId: getZelFluxTimezone
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Timezone
+              example:
+                status: success
+                data: Europe/Berlin
+  /zelflux/version:
     get:
       tags:
         - ZelFlux
       summary: Gets version of ZelFlux
-      description: Gets version of ZelFlux running on the ZelNode the call is run against as it is in package.json. ZELTEAM
+      description: >-
+        Gets version of ZelFlux running on the ZelNode the call is run against
+        as it is in package.json. **PUBLIC**
       operationId: getZelFluxVersion
       responses:
         '200':
@@ -600,31 +1042,11258 @@ paths:
               schema:
                 type: object
                 properties:
-                  status: 
+                  status:
                     $ref: '#/components/schemas/status'
                   data:
                     type: string
-                    description: ZelFlux version
+                    description: Zelflux version
               example:
                 status: success
-                data: '0.41.1'
-# An object to hold reusable parts that can be used across the spec
+                data: 0.41.1
+  /zelflux/ip:
+    get:
+      tags:
+        - ZelFlux
+      summary: ZelFlux IP
+      description: >-
+        This will return with the IP address of the server that ZelFlux is on.
+        **PUBLIC**
+      operationId: getZelFluxIP
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: IP address
+              example:
+                status: success
+                data: 49.12.8.215
+  /zelflux/zelid:
+    get:
+      tags:
+        - ZelFlux
+      summary: Admin's ZelID
+      description: This will return with the admin's ZelID. **PUBLIC**
+      operationId: getZelFluxZelID
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: ZelID
+              example:
+                status: success
+                data: 1CcoEkKQZcwUXPSps4bZJDjUM3mqe9bNXf
+  /zelflux/dosstate:
+    get:
+      tags:
+        - ZelFlux
+      summary: DOS state
+      description: >-
+        This will return with the DOS state that ZelFlux is in from 0-10 and if
+        it reaches 10 it gets banned. **PUBLIC**
+      operationId: getDOSState
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    items:
+                      properties:
+                        dosState:
+                          type: integer
+                          description: Status number
+                        dosMessage:
+                          type: string
+                          description: Explanation of status
+              example:
+                status: success
+                data:
+                  dosState: 0
+                  dosMessage: null
+  /zelflux/connectedpeers:
+    get:
+      tags:
+        - ZelFlux
+      summary: Gets IP's of connected peers
+      description: Gets list of IP addresses of outgoing connected peers. **PUBLIC**
+      operationId: connectedPeers
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: string
+                      description: IP of connected peer
+              example:
+                status: success
+                data:
+                  - 193.188.15.252
+                  - 164.68.127.146
+                  - 188.239.61.176
+                  - 89.187.128.108
+  /zelflux/connectedpeersinfo:
+    get:
+      tags:
+        - ZelFlux
+      summary: Gets info of connected peers
+      description: >-
+        Gets list of ip addresses and rtt of the outgoing connected peers.
+        **PUBLIC**
+      operationId: connectedPeersInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        ip:
+                          type: string
+                          description: Ip address of connected peer
+                        rtt:
+                          type: integer
+                          description: >-
+                            Round trip time of packets being sent back and forth
+                            between peers
+              example:
+                status: success
+                data:
+                  - ip: 193.188.15.252
+                    rtt: 27
+                  - ip: 164.68.127.146
+                    rtt: 196
+                  - ip: 188.239.61.176
+                    rtt: 202
+                  - ip: 89.187.128.108
+                    rtt: 214
+  /zelflux/incomingconnections:
+    get:
+      tags:
+        - ZelFlux
+      summary: List of incoming connections
+      description: Gets list of IP addresses of incoming connected peers. **PUBLIC**
+      operationId: incomingConnections
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: string
+                      description: Ip list of incoming connections
+              example:
+                status: success
+                data:
+                  - '::ffff:91.238.104.205'
+                  - '::ffff:192.81.130.145'
+                  - '::ffff:167.86.71.144'
+                  - '::ffff:193.188.15.254'
+                  - '::ffff:62.171.188.152'
+                  - '::ffff:164.68.125.203'
+  /zelflux/incomingconnectionsinfo:
+    get:
+      tags:
+        - ZelFlux
+      summary: Gets info of incoming connections
+      description: Gets list of ip addresses and rtt of incoming connections. **PUBLIC**
+      operationId: incomingConnectionsInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        ip:
+                          type: string
+                          description: Ip address of incoming connection
+                        rtt:
+                          type: string
+                          description: >-
+                            Round trip time of packets being sent back and forth
+                            for incoming connection
+              example:
+                status: success
+                data:
+                  - ip: '::ffff:91.238.104.205'
+                    rtt: 210
+                  - ip: '::ffff:192.81.130.145'
+                    rtt: 196
+                  - ip: '::ffff:167.86.71.144'
+                    rtt: null
+                  - ip: '::ffff:193.188.15.254'
+                    rtt: 214
+                  - ip: '::ffff:62.171.188.152'
+                    rtt: 194
+                  - ip: '::ffff:164.68.125.203'
+                    rtt: 205
+  /zelflux/checkfluxavailability:
+    get:
+      tags:
+        - ZelFlux
+      summary: Check availability of ZelFlux
+      description: >-
+        Check if ZelFlux is reachable and available using IP of the ZelFlux's
+        server. **PUBLIC**
+      operationId: checkFluxAvailability
+      parameters:
+        - in: query
+          name: ip
+          required: true
+          schema:
+            type: string
+          description: Ip address
+          example: '?ip=193.188.15.245'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: sucess
+                data:
+                  message: Asking Flux is available
+  /zelflux/broadcastmessage:
+    post:
+      tags:
+        - ZelFlux
+      summary: Broadcast message to peers
+      description: Broadcast message to peers that are connected. **ZELTEAM** **ADMIN**
+      operationId: broadcastMessageFromUserPost
+      security:
+        - ZelID: []
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+                  description: The message
+            example:
+              data: Helloworld
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: Message successfully broadcasted to ZelFlux network
+    get:
+      tags:
+        - ZelFlux
+      summary: Broadcast message to peers
+      description: Broadcast message to peers that are connected. **ZELTEAM** **ADMIN**
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: data
+          required: true
+          schema:
+            type: string
+          description: The message
+          example: '?data=HelloWorld'
+      operationId: broadcastMessageFromUser
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: Message successfully broadcasted to ZelFlux network
+  /zelflux/broadcastmessagetooutgoing:
+    post:
+      tags:
+        - ZelFlux
+      summary: Broadcast message to outgoing peers
+      description: >-
+        Broadcast message to peers on outgoing connections. **ZELTEAM**
+        **ADMIN**
+      operationId: broadcastMessageToOutgoingFromUserPost
+      security:
+        - ZelID: []
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+                  description: The message
+            example:
+              data: Helloworld
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: Message successfully broadcasted to ZelFlux network
+    get:
+      tags:
+        - ZelFlux
+      summary: Broadcast message to outgoing peers
+      description: >-
+        Broadcast message to peers on outgoing connections. **ZELTEAM**
+        **ADMIN**
+      operationId: broadcastMessageToOutgoingFromUser
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: data
+          required: true
+          schema:
+            type: string
+          description: The message
+          example: '?data=HelloWorld'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: Message successfully broadcasted to ZelFlux network
+  /zelflux/broadcastmessagetoincoming:
+    post:
+      tags:
+        - ZelFlux
+      summary: Broadcast message to incoming peers
+      description: >-
+        Broadcast message to peers on incoming connections. **ZELTEAM**
+        **ADMIN**
+      operationId: broadcastMessageToIncomingFromUserPost
+      security:
+        - ZelID: []
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+                  description: The message
+            example:
+              data: Helloworld
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: Message successfully broadcasted to ZelFlux network
+    get:
+      tags:
+        - ZelFlux
+      summary: Broadcast message to incoming peers
+      description: >-
+        Broadcast message to peers on incoming connections. **ZELTEAM**
+        **ADMIN**
+      operationId: broadcastMessageToIncomingFromUser
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: data
+          required: true
+          schema:
+            type: string
+          description: The message
+          example: '?data=HelloWorld'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: Message successfully broadcasted to ZelFlux network
+  /zelflux/addpeer:
+    get:
+      tags:
+        - ZelFlux
+      summary: Add peer option
+      description: >-
+        This call gives option to add peers to outgoing connections. **ZELTEAM**
+        **ADMIN**
+      operationId: addPeer
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: ip
+          required: true
+          schema:
+            type: string
+          description: Ip of peer to add
+          example: '?ip=49.12.8.215'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: Outgoing connection to 49.12.8.215 initiated
+  /zelflux/removepeer:
+    get:
+      tags:
+        - ZelFlux
+      summary: Remove peer option
+      description: >-
+        This call does exact opposite of add and removes/drops a outgoing
+        connected peer. **ZELTEAM** **ADMIN**
+      operationId: removePeer
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: ip
+          required: true
+          schema:
+            type: string
+          description: Ip of peer to remove
+          example: '?ip=49.12.8.215'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: Outgoing connection to 49.12.8.215 closed
+  /zelflux/removeincomingpeer:
+    get:
+      tags:
+        - ZelFlux
+      summary: Remove incoming peer
+      description: Remove a incoming connected peer. **ZELTEAM** **ADMIN**
+      operationId: removeIncomingPeer
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: ip
+          required: true
+          schema:
+            type: string
+          description: Ip of peer to remove
+          example: '?ip=49.12.8.215'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: Incoming connection to 49.12.8.215 closed
+  /zelflux/allowport:
+    get:
+      tags:
+        - ZelFlux
+      summary: Open port on server
+      description: >-
+        This will open a port on the server and adding it to the firewall rules.
+        **ZELTEAM** **ADMIN**
+      operationId: allowPortApi
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: port
+          required: true
+          schema:
+            type: integer
+          description: Port number to open
+          example: '?port=22222'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      code:
+                        type: integer
+                        description: Port number
+                      name:
+                        type: integer
+                        description: Port number
+                      message:
+                        type: string
+                        description: Explanation of status
+              example:
+                status: success
+                data:
+                  code: 22222
+                  name: 22222
+                  message: Rule added\nRule added (v6)\n
+  /zelcash/help:
+    get:
+      tags:
+        - ZelCash
+      summary: RPC list
+      description: >-
+        Gets list of RPC for the Zelcash daemon or if command query is used it
+        will respond with the help info for that specified call. **PUBLIC**
+      operationId: help
+      parameters:
+        - in: query
+          name: command
+          schema:
+            type: string
+          description: >-
+            Accepts both help/command and ?command=getinfo. If omited, default
+            help will be displayed.
+          example: '?command=getmininginfo'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: RPC list
+              example:
+                status: success
+                data: >-
+                  == Addressindex ==
+
+                  getaddressbalance {"addresses": ["taddr", ...]}
+
+                  getaddressdeltas {"addresses": ["taddr", ...], ("start": n),
+                  ("end": n), ("chainInfo": true|false)}
+
+                  getaddressmempool {"addresses": ["taddr", ...]}
+
+                  getaddresstxids {"addresses": ["taddr", ...], ("start": n),
+                  ("end": n)}
+
+                  getaddressutxos {"addresses": ["taddr", ...], ("chainInfo":
+                  true|false)}
+
+
+                  == Benchmarks ==
+
+                  getbenchmarks
+
+                  getbenchstatus
+
+                  startzelbenchd
+
+                  stopzelbenchd
+
+
+                  == Blockchain ==
+
+                  getbestblockhash
+
+                  getblock "hash|height" ( verbosity )
+
+                  getblockchaininfo
+
+                  getblockcount
+
+                  getblockdeltas "blockhash"
+
+                  getblockhash index
+
+                  getblockhashes high low ( {"noOrphans": true|false,
+                  "logicalTimes": true|false} )
+
+                  getblockheader "hash" ( verbose )
+
+                  getchaintips
+
+                  getdifficulty
+
+                  getmempoolinfo
+
+                  getrawmempool ( verbose )
+
+                  getspentinfo {"txid": "txidhex", "index": n}
+
+                  gettxout "txid" n ( includemempool )
+
+                  gettxoutproof ["txid",...] ( blockhash )
+
+                  gettxoutsetinfo
+
+                  verifychain ( checklevel numblocks )
+
+                  verifytxoutproof "proof"
+
+
+                  == Control ==
+
+                  getinfo
+
+                  help ( "command" )
+
+                  stop
+
+
+                  == Disclosure ==
+
+                  z_getpaymentdisclosure "txid" "js_index" "output_index"
+                  ("message") 
+
+                  z_validatepaymentdisclosure "paymentdisclosure"
+
+
+                  == Generating ==
+
+                  generate numblocks
+
+                  getgenerate
+
+                  setgenerate generate ( genproclimit )
+
+
+                  == Mining ==
+
+                  getblocksubsidy height
+
+                  getblocktemplate ( "jsonrequestobject" )
+
+                  getlocalsolps
+
+                  getmininginfo
+
+                  getnetworkhashps ( blocks height )
+
+                  getnetworksolps ( blocks height )
+
+                  prioritisetransaction <txid> <priority delta> <fee delta>
+
+                  submitblock "hexdata" ( "jsonparametersobject" )
+
+
+                  == Network ==
+
+                  addnode "node" "add|remove|onetry"
+
+                  clearbanned
+
+                  disconnectnode "node" 
+
+                  getaddednodeinfo dns ( "node" )
+
+                  getconnectioncount
+
+                  getdeprecationinfo
+
+                  getnettotals
+
+                  getnetworkinfo
+
+                  getpeerinfo
+
+                  listbanned
+
+                  ping
+
+                  setban "ip(/netmask)" "add|remove" (bantime) (absolute)
+
+
+                  == Rawtransactions ==
+
+                  createrawtransaction [{"txid":"id","vout":n},...]
+                  {"address":amount,...} ( locktime ) ( expiryheight )
+
+                  decoderawtransaction "hexstring"
+
+                  decodescript "hex"
+
+                  fundrawtransaction "hexstring"
+
+                  getrawtransaction "txid" ( verbose )
+
+                  sendrawtransaction "hexstring" ( allowhighfees )
+
+                  signrawtransaction "hexstring" (
+                  [{"txid":"id","vout":n,"scriptPubKey":"hex","redeemScript":"hex"},...]
+                  ["privatekey1",...] sighashtype )
+
+
+                  == Util ==
+
+                  createmultisig nrequired ["key",...]
+
+                  estimatefee nblocks
+
+                  estimatepriority nblocks
+
+                  validateaddress "zelcashaddress"
+
+                  verifymessage "zelcashaddress" "signature" "message"
+
+                  z_validateaddress "zaddr"
+
+
+                  == Wallet ==
+
+                  addmultisigaddress nrequired ["key",...] ( "account" )
+
+                  backupwallet "destination"
+
+                  dumpprivkey "t-addr"
+
+                  dumpwallet "folder/filename"
+
+                  encryptwallet "passphrase"
+
+                  getaccount "zelcashaddress"
+
+                  getaccountaddress "account"
+
+                  getaddressesbyaccount "account"
+
+                  getbalance ( "account" minconf includeWatchonly )
+
+                  getnewaddress ( "account" )
+
+                  getrawchangeaddress
+
+                  getreceivedbyaccount "account" ( minconf )
+
+                  getreceivedbyaddress "zelcashaddress" ( minconf )
+
+                  gettransaction "txid" ( includeWatchonly )
+
+                  getunconfirmedbalance
+
+                  getwalletinfo
+
+                  importaddress "address" ( "label" rescan )
+
+                  importprivkey "zelcashprivkey" ( "label" rescan )
+
+                  importwallet "filename"
+
+                  keypoolrefill ( newsize )
+
+                  listaccounts ( minconf includeWatchonly)
+
+                  listaddressgroupings
+
+                  listlockunspent
+
+                  listreceivedbyaccount ( minconf includeempty includeWatchonly)
+
+                  listreceivedbyaddress ( minconf includeempty includeWatchonly)
+
+                  listsinceblock ( "blockhash" target-confirmations
+                  includeWatchonly)
+
+                  listtransactions ( "account" count from includeWatchonly)
+
+                  listunspent ( minconf maxconf  ["address",...] )
+
+                  lockunspent unlock [{"txid":"txid","vout":n},...]
+
+                  move "fromaccount" "toaccount" amount ( minconf "comment" )
+
+                  rescanblockchain (start_height)
+
+                  sendfrom "fromaccount" "tozelcashaddress" amount ( minconf
+                  "comment" "comment-to" )
+
+                  sendmany "fromaccount" {"address":amount,...} ( minconf
+                  "comment" ["address",...] )
+
+                  sendtoaddress "zelcashaddress" amount ( "comment" "comment-to"
+                  subtractfeefromamount )
+
+                  setaccount "zelcashaddress" "account"
+
+                  settxfee amount
+
+                  signmessage "t-addr" "message"
+
+                  z_exportkey "zaddr"
+
+                  z_exportviewingkey "zaddr"
+
+                  z_exportwallet "folder/filename"
+
+                  z_getbalance "address" ( minconf )
+
+                  z_getmigrationstatus
+
+                  z_getnewaddress ( type )
+
+                  z_getoperationresult (["operationid", ... ]) 
+
+                  z_getoperationstatus (["operationid", ... ]) 
+
+                  z_gettotalbalance ( minconf includeWatchonly )
+
+                  z_importkey "zkey" ( rescan startHeight )
+
+                  z_importviewingkey "vkey" ( rescan startHeight )
+
+                  z_importwallet "filename"
+
+                  z_listaddresses ( includeWatchonly )
+
+                  z_listoperationids
+
+                  z_listreceivedbyaddress "address" ( minconf )
+
+                  z_listunspent ( minconf maxconf includeWatchonly ["zaddr",...]
+                  )
+
+                  z_mergetoaddress ["fromaddress", ... ] "toaddress" ( fee ) (
+                  transparent_limit ) ( shielded_limit ) ( memo )
+
+                  z_sendmany "fromaddress" [{"address":... ,"amount":...},...] (
+                  minconf ) ( fee )
+
+                  z_setmigration enabled
+
+                  z_shieldcoinbase "fromaddress" "tozaddress" ( fee ) ( limit )
+
+                  zcbenchmark benchmarktype samplecount
+
+                  zcrawjoinsplit rawtx inputs outputs vpub_old vpub_new
+
+                  zcrawkeygen
+
+                  zcrawreceive zcsecretkey encryptednote
+
+                  zcsamplejoinsplit
+
+
+                  == Zelnode ==
+
+                  createzelnodebroadcast "command" ( "alias")
+
+                  createzelnodekey
+
+                  decodezelnodebroadcast "hexstring"
+
+                  getzelnodecount
+
+                  getzelnodeoutputs
+
+                  getzelnodescores ( blocks )
+
+                  getzelnodestatus
+
+                  getzelnodewinners ( blocks "filter" )
+
+                  listzelnodeconf ( "filter" )
+
+                  listzelnodes ( "filter" )
+
+                  relayzelnodebroadcast "hexstring"
+
+                  spork "name" ( value )
+
+                  startdeterministiczelnode alias_name lockwallet
+
+                  startzelnode "all|alias" lockwallet ( "alias" )
+
+                  viewdeterministiczelnodelist ( "filter" )
+
+                  zelnodecurrentwinner
+
+                  zelnodedebug
+
+                  znsync "status|reset"
+  /zelcash/getinfo:
+    get:
+      tags:
+        - ZelCash
+      summary: Zelcash daemon info
+      description: >-
+        Returns an object containing various state info for the Zelcash daemon.
+        **PUBLIC**
+      operationId: getInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/zelcashgetinfo'
+              example:
+                status: success
+                data:
+                  version: 4000150
+                  protocolversion: 170016
+                  walletversion: 60000
+                  balance: 0
+                  blocks: 585849
+                  timeoffset: 0
+                  connections: 33
+                  proxy: ''
+                  difficulty: 2885.838697886431
+                  testnet: false
+                  keypoololdest: 1585688609
+                  keypoolsize: 101
+                  paytxfee: 0
+                  relayfee: 0.000001
+                  errors: ''
+  /zelcash/getzelnodestatus:
+    get:
+      tags:
+        - ZelCash
+      summary: ZelNode status
+      description: Returns an object containing various state of the ZelNode. **PUBLIC**
+      operationId: getZelNodeStatus
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/zelnodestatus'
+              example:
+                status: success
+                data:
+                  status: CONFIRMED
+                  collateral: >-
+                    COutPoint(5179622de68fac4c052c0ce1affeaa3faaf4624d7332f769f3fc5c42560455b6,
+                    0)
+                  txhash: >-
+                    5179622de68fac4c052c0ce1affeaa3faaf4624d7332f769f3fc5c42560455b6
+                  outidx: 0
+                  ip: 144.91.114.167
+                  network: ipv4
+                  added_height: 572386
+                  confirmed_height: 572389
+                  last_confirmed_height: 586403
+                  last_paid_height: 586319
+                  tier: SUPER
+                  payment_address: t1h7HLNYNmG6mZF8WC6BRLHqCib8hMqP3XC
+                  pubkey: >-
+                    0485c289e6df683ac2af0ce514260a20cc5a631336fee6bbcb897694134c5a5ad2a5d918f99d70a60c0cb30c705a8c5440f1cbca08e6d3f037320f40751c50555c
+                  activesince: 1586334448
+                  lastpaid: 1588014482
+  /zelcash/listzelnodes:
+    get:
+      tags:
+        - ZelCash
+      summary: ZelNode list
+      description: Gets a ranked list of Zelnodes. **PUBLIC**
+      operationId: listZelNodes
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        collateral:
+                          type: string
+                          description: Collateral txid and output index
+                        ip:
+                          type: string
+                          description: Ip address of ZelNode server
+                        added_height:
+                          type: integer
+                          description: Block height ZelNode was added to list
+                        confirmed_height:
+                          type: integer
+                          description: Block height ZelNode was confirmed by the network
+                        last_confirmed_height:
+                          type: integer
+                          description: Latest block height network confirmed the ZelNode
+                        last_paid_height:
+                          type: integer
+                          description: Block the ZelNode was last paid
+                        tier:
+                          type: string
+                          description: Tier of ZelNode
+                        payment_address:
+                          type: string
+                          description: Address where rewards are paid
+                        activesince:
+                          type: integer
+                          description: Active time of ZelNode in epoch
+                        lastpaid:
+                          type: integer
+                          description: Last paid time in epoch
+                        rank:
+                          type: integer
+                          description: Rank of ZelNode
+              example:
+                status: success
+                data:
+                  - collateral: >-
+                      COutPoint(826d37f13065e87f77ce1667e035b30933f78462274062aa7e76f249b6ab59db,
+                      0)
+                    ip: 95.216.236.190
+                    added_height: 562050
+                    confirmed_height: 562053
+                    last_confirmed_height: 588205
+                    last_paid_height: 587939
+                    tier: BASIC
+                    payment_address: t1KrT6iKh384mQHwfAPcEFm3U7yFKwhmHbo
+                    activesince: 1585083381
+                    lastpaid: 1588210538
+                    rank: 0
+                  - collateral: >-
+                      COutPoint(3798162c2b60906a9feff0efa38b57444f3749bebe397cba4edd495b929ed9b5,
+                      0)
+                    ip: 77.55.194.135
+                    added_height: 587653
+                    confirmed_height: 587669
+                    last_confirmed_height: 588184
+                    last_paid_height: 587940
+                    tier: BASIC
+                    payment_address: t1QEA6PepP2wS3Lg6gZDiFzRB6PfxWLYeK5
+                    activesince: 1588175897
+                    lastpaid: 1588210563
+                    rank: 1
+                  - collateral: >-
+                      COutPoint(a375169d97fcafac46f673045dfa0a78dd78e6bc6db181df18bf39dbe03926a4,
+                      0)
+                    ip: 96.52.90.87
+                    added_height: 572579
+                    confirmed_height: 572581
+                    last_confirmed_height: 588198
+                    last_paid_height: 587986
+                    tier: SUPER
+                    payment_address: t1a4J5u9rjrgVZLwRPSy7VPNoVVkeErNErk
+                    activesince: 1586358287
+                    lastpaid: 1588216950
+                    rank: 0
+                  - collateral: >-
+                      COutPoint(381d29a87b96e82253b3f9581618777469f854ae740b6a785c61867aa6f71e60,
+                      0)
+                    ip: 207.180.253.144
+                    added_height: 585797
+                    confirmed_height: 585799
+                    last_confirmed_height: 588206
+                    last_paid_height: 587988
+                    tier: SUPER
+                    payment_address: t1ZvKaPfgXJsY1DkYJ5gKwtjKFUkZcuQB2U
+                    activesince: 1587952571
+                    lastpaid: 1588217098
+                    rank: 1
+                  - collateral: >-
+                      COutPoint(1a2c265b7d1d93941c4d551e61c90cc14482579835a4924e1e169339317bbef9,
+                      0)
+                    ip: 47.22.47.186
+                    added_height: 582736
+                    confirmed_height: 582738
+                    last_confirmed_height: 588198
+                    last_paid_height: 588034
+                    tier: BAMF
+                    payment_address: t1bNJrZ9JwWwvroT7YUJUSDfMQ2r21vZppe
+                    activesince: 1587582537
+                    lastpaid: 1588222759
+                    rank: 0
+  /zelcash/viewdeterministiczelnodelist:
+    get:
+      tags:
+        - ZelCash
+      summary: Deterministic ZelNode list
+      description: View deterministic list of ZelNodes by rank. **PUBLIC**
+      operationId: viewDeterministicZelNodeList
+      parameters:
+        - in: query
+          name: filter
+          schema:
+            type: string
+          description: >-
+            Accepts both viewdeterministiczelnodelist/filter and
+            ?filter=193.188.15.238. Filter query will filter list by ,txhash,
+            payment address, ip, or pubkey. If ommited, full list will be
+            displayed.
+          example: '?filter=193.188.15.238'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        collateral:
+                          type: string
+                          description: Collateral txid and output index
+                        txhash:
+                          type: string
+                          description: Transaction id
+                        outidx:
+                          type: integer
+                          description: Output index
+                        ip:
+                          type: string
+                          description: Ip address of ZelNode server
+                        network:
+                          type: string
+                          description: 'Network type (IPv4, IPv6, onion)'
+                        added_height:
+                          type: integer
+                          description: Block height ZelNode was added to list
+                        confirmed_height:
+                          type: integer
+                          description: Block height ZelNode was confirmed by the network
+                        last_confirmed_height:
+                          type: integer
+                          description: Latest block height network confirmed the ZelNode
+                        last_paid_height:
+                          type: integer
+                          description: Block the ZelNode was last paid
+                        tier:
+                          type: string
+                          description: Tier of ZelNode
+                        payment_address:
+                          type: string
+                          description: Address where rewards are paid
+                        pubkey:
+                          type: string
+                          description: Zelnode public key used for message broadcasting
+                        activesince:
+                          type: integer
+                          description: Active time of ZelNode in epoch
+                        lastpaid:
+                          type: integer
+                          description: Last paid time in epoch
+                        rank:
+                          type: integer
+                          description: Rank of ZelNode
+              example:
+                status: success
+                data:
+                  - collateral: >-
+                      COutPoint(436d3450affca4dd78a3755f816eb7d46f922dd430e0046b94f26ce88c008e79,
+                      0)
+                    txhash: >-
+                      436d3450affca4dd78a3755f816eb7d46f922dd430e0046b94f26ce88c008e79
+                    outidx: 0
+                    ip: 77.55.210.97
+                    network: ipv4
+                    added_height: 562050
+                    confirmed_height: 562053
+                    last_confirmed_height: 588205
+                    last_paid_height: 587939
+                    tier: BASIC
+                    payment_address: t1ZhnnTVUfgwKbmtFvmYtSb1xwPpSdJmzaY
+                    pubkey: >-
+                      043249d5fc0517976c8eeaaf96ce306c00687cea677be0181cdddaf8f8e044119f13258083fb0a8e98afdf57994331cd1e71958ce63b7b2d0a2dda0e095bd2a2de
+                    activesince: 1585083381
+                    lastpaid: 1588210538
+                    rank: 0
+                  - collateral: >-
+                      COutPoint(62e0f589a36b9d009f060bcb062a9baf0a44ed3cb5fb4ba68fb5e8d1c6a76ed3,
+                      0)
+                    txhash: >-
+                      62e0f589a36b9d009f060bcb062a9baf0a44ed3cb5fb4ba68fb5e8d1c6a76ed3
+                    outidx: 0
+                    ip: 207.180.238.133
+                    network: ipv4
+                    added_height: 587653
+                    confirmed_height: 587669
+                    last_confirmed_height: 588184
+                    last_paid_height: 587940
+                    tier: BASIC
+                    payment_address: t1WWAUFtKyytFzuXpn3Rzc6fGFndzD6xWLK
+                    pubkey: >-
+                      0450331d67221677cdca27c7cce40c52d3f3aae1c71a3dbf0c7322a7739bb42855246a9ab3a0b4280f20a6ebb3bf4dcc2a2290b74e533560d9c64014d8937bd1bb
+                    activesince: 1588175897
+                    lastpaid: 1588210563
+                    rank: 1
+                  - collateral: >-
+                      COutPoint(b81456f6cb28cab6bb7c715a26cb40dbe841e9d14bf47aadbf7a50fb8a32f7f4,
+                      0)
+                    txhash: >-
+                      b81456f6cb28cab6bb7c715a26cb40dbe841e9d14bf47aadbf7a50fb8a32f7f4
+                    outidx: 0
+                    ip: 49.12.41.242
+                    network: ipv4
+                    added_height: 572579
+                    confirmed_height: 572581
+                    last_confirmed_height: 588198
+                    last_paid_height: 587986
+                    tier: SUPER
+                    payment_address: t1Wz3D8rTRB3xZi8WE8efgMzRwHhpg8dAWF
+                    pubkey: >-
+                      04e993a952569ecd6eb26eac7abdb699ca8e3f1debeaf544ef85b3c5838b74d7b30e196e917cb6e2008b2dcb9e42cafc4c93ccafb2888faea26b2e3a1a343f469a
+                    activesince: 1586358287
+                    lastpaid: 1588216950
+                    rank: 0
+                  - collateral: >-
+                      COutPoint(db8d6440f834f773561025c7327620bb1770df185ec506323f084c436eb9fca7,
+                      0)
+                    txhash: >-
+                      db8d6440f834f773561025c7327620bb1770df185ec506323f084c436eb9fca7
+                    outidx: 0
+                    ip: 62.171.183.202
+                    network: ipv4
+                    added_height: 585797
+                    confirmed_height: 585799
+                    last_confirmed_height: 588206
+                    last_paid_height: 587988
+                    tier: SUPER
+                    payment_address: t1bXEnPZ22LRtd8WCmmKZAF2gxqaAxWysTb
+                    pubkey: >-
+                      04bfdff6a29281e057f10c2162db0ba98f70133fc45ccfa3cd8440a1ddc0ae30172b81f73b098cfdfe5f413a361dc422a03a31066413850ba418f3f8a2df65a4e1
+                    activesince: 1587952571
+                    lastpaid: 1588217098
+                    rank: 1
+                  - collateral: >-
+                      COutPoint(8dcdf431d67c54872dcbbbfe205df8d95bdf8d0c277f617ded10ff74d9242878,
+                      0)
+                    txhash: >-
+                      8dcdf431d67c54872dcbbbfe205df8d95bdf8d0c277f617ded10ff74d9242878
+                    outidx: 0
+                    ip: 188.239.61.210
+                    network: ipv4
+                    added_height: 582736
+                    confirmed_height: 582738
+                    last_confirmed_height: 588198
+                    last_paid_height: 588034
+                    tier: BAMF
+                    payment_address: t1ZPnohxvacmT8VaJqRyZyMkvzERddQMttk
+                    pubkey: >-
+                      0418588b950297e955f7cc211c4d32f4f976433e8f1d4e2f2f0c4a1efd0e7a3b5167f27a0ad92ceedfa5b40862d929934a5d453f1268ee36b6ec22a7e921883454
+                    activesince: 1587582537
+                    lastpaid: 1588222759
+                    rank: 0
+  /zelcash/getzelnodecount:
+    get:
+      tags:
+        - ZelCash
+      summary: ZelNode count
+      description: >-
+        Returns a count of ZelNodes and enabled ZelNodes categorized by tiers.
+        **PUBLIC**
+      operationId: getZelNodeCount
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      total:
+                        type: number
+                        description: Total number of ZelNodes
+                      stable:
+                        type: number
+                        description: Number of stable ZelNodes
+                      basic-enabled:
+                        type: number
+                        description: Basic ZelNode count
+                      super-enabled:
+                        type: number
+                        description: Super ZelNode count
+                      bamf-enabled:
+                        type: number
+                        description: Bamf ZelNode count
+                      ipv4:
+                        type: number
+                        description: ZelNodes on ipv4
+                      ipv6:
+                        type: number
+                        description: ZelNodes on ipv6
+                      onion:
+                        type: string
+                        description: ZelNodes on tor
+              example:
+                status: success
+                data:
+                  total: 692
+                  stable: 692
+                  basic-enabled: 293
+                  super-enabled: 231
+                  bamf-enabled: 174
+                  ipv4: 692
+                  ipv6: 0
+                  onion: 0
+  /zelcash/spork:
+    get:
+      tags:
+        - ZelCash
+      summary: Spork info
+      description: Return spork values or their active state. **PUBLIC**
+      operationId: spork
+      parameters:
+        - in: query
+          name: name
+          schema:
+            type: string
+          description: >-
+            Use "show" to get values or "active" to show active state. When set
+            up as a spork signer, the name of the spork can be used to update
+            it's value.
+          example: '?name=show'
+        - in: query
+          name: value
+          schema:
+            type: integer
+          description: The value for the spork..
+          example: '?name=...&value=4070908800'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      SPORK_1_ZELNODE_PAYMENT_ENFORCEMENT:
+                        type: integer
+                        description: Name of spork and value
+                      SPORK_2_ZELNODE_UPGRADE_VOTE_ENFORCEMENT:
+                        type: integer
+                        description: Name of spork and value
+              example:
+                status: success
+                data:
+                  SPORK_1_ZELNODE_PAYMENT_ENFORCEMENT: 4070908800
+                  SPORK_2_ZELNODE_UPGRADE_VOTE_ENFORCEMENT: 4070908800
+  /zelcash/zelnodecurrentwinner:
+    get:
+      tags:
+        - ZelCash
+      summary: Current list of winners
+      description: Gets a list of current ZelNode winners. **PUBLIC**
+      operationId: zelNodeCurrentWinner
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      BASIC Winner:
+                        type: object
+                        properties:
+                          collateral:
+                            type: string
+                            description: Collateral txid and output index of ZelNode
+                          ip:
+                            type: string
+                            description: Ip address of ZelNode
+                          added_height:
+                            type: integer
+                            description: Block height ZelNode was added
+                          confirmed_height:
+                            type: integer
+                            description: Block height ZelNode was confirmed
+                          last_confirmed_height:
+                            type: integer
+                            description: Block height ZelNode was last confirmed
+                          last_paid_height:
+                            type: integer
+                            description: Block height ZelNode was last paid
+                          tier:
+                            type: string
+                            description: ZelNode tier
+                          payment_address:
+                            type: string
+                            description: Payment address
+                      SUPER Winner:
+                        type: object
+                        properties:
+                          collateral:
+                            type: string
+                            description: Collateral txid and output index of ZelNode
+                          ip:
+                            type: string
+                            description: Ip address of ZelNode
+                          added_height:
+                            type: integer
+                            description: Block height ZelNode was added
+                          confirmed_height:
+                            type: integer
+                            description: Block height ZelNode was confirmed
+                          last_confirmed_height:
+                            type: integer
+                            description: Block height ZelNode was last confirmed
+                          last_paid_height:
+                            type: integer
+                            description: Block height ZelNode was last paid
+                          tier:
+                            type: string
+                            description: ZelNode tier
+                          payment_address:
+                            type: string
+                            description: Payment address
+                      BAMF Winner:
+                        type: object
+                        properties:
+                          collateral:
+                            type: string
+                            description: Collateral txid and output index of ZelNode
+                          ip:
+                            type: string
+                            description: Ip address of ZelNode
+                          added_height:
+                            type: integer
+                            description: Block height ZelNode was added
+                          confirmed_height:
+                            type: integer
+                            description: Block height ZelNode was confirmed
+                          last_confirmed_height:
+                            type: integer
+                            description: Block height ZelNode was last confirmed
+                          last_paid_height:
+                            type: integer
+                            description: Block height ZelNode was last paid
+                          tier:
+                            type: string
+                            description: ZelNode tier
+                          payment_address:
+                            type: string
+                            description: Payment address
+              example:
+                status: success
+                data:
+                  BASIC Winner:
+                    collateral: >-
+                      COutPoint(5e6fdf0a56de71c3fcaf4091097d8feea7b3e1f966e334b7ea234a616813f934,
+                      0)
+                    ip: 66.119.15.218
+                    added_height: 589025
+                    confirmed_height: 589026
+                    last_confirmed_height: 590742
+                    last_paid_height: 590489
+                    tier: BASIC
+                    payment_address: t1VLEe6iBNGGicyiqQNzGWsZ6Z6pNZZrTyq
+                  SUPER Winner:
+                    collateral: >-
+                      COutPoint(4da9b0320ab1a1e94662471732b722667cd68a25d5db72f18572e36f63452872,
+                      0)
+                    ip: 85.23.158.111
+                    added_height: 585221
+                    confirmed_height: 585222
+                    last_confirmed_height: 590742
+                    last_paid_height: 590538
+                    tier: SUPER
+                    payment_address: t1WdrzqRR4gh73mPJpN3PDB9a9ZFiatP9tp
+                  BAMF Winner:
+                    collateral: >-
+                      COutPoint(7f69bbb001f27177d2b60b99e3dbe3d95b82b69b8d82a21b9829ddc27af2be01,
+                      0)
+                    ip: 193.188.15.153
+                    added_height: 587646
+                    confirmed_height: 587649
+                    last_confirmed_height: 590742
+                    last_paid_height: 590594
+                    tier: BAMF
+                    payment_address: t1dDaoT2WDv5M5gTdx7CzLgXEQSEeqVkryw
+  /zelcash/getbestblockhash:
+    get:
+      tags:
+        - ZelCash
+      summary: Block hash of tip on longest chain
+      description: >-
+        Returns the hash of the best (tip) block in the longest block chain.
+        **PUBLIC**
+      operationId: getBestBlockHash
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Block hash
+              example:
+                status: success
+                data: >-
+                  00000045ee2d11311976f420b0d753dc7a6e2800a36cf07f6ec1572699737ab6
+  /zelcash/getblock:
+    get:
+      tags:
+        - ZelCash
+      summary: Get block data
+      description: >-
+        Gets block data using block height or block hash you specify to get info
+        for with verbosity option. **PUBLIC**
+      operationId: getBlock
+      parameters:
+        - in: query
+          name: hashheight
+          required: true
+          schema:
+            type: integer
+          description: Block hash or height
+          example: '?hashheight=588530'
+        - in: query
+          name: verbosity
+          schema:
+            type: integer
+            enum:
+              - 0
+              - 1
+              - 2
+            default: 1
+          description: >-
+            If verbosity is 0, returns a string that is serialized, hex-encoded
+            data for the block. If verbosity is 1, returns an Object with
+            information about the block. If verbosity is 2, returns an Object
+            with information about the block and information about each
+            transaction. Response example shown is using the default value of 1.
+          example: '?hashheight=...&verbosity=1'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      hash:
+                        type: string
+                        description: The block hash
+                      confirmations:
+                        type: string
+                        description: The number of confirmations or -1 if on wrong chain
+                      size:
+                        type: integer
+                        description: The block size
+                      height:
+                        type: integer
+                        description: The block height or index
+                      version:
+                        type: integer
+                        description: The block version
+                      merkleroot:
+                        type: string
+                        description: The merkle root
+                      finalsaplingroot:
+                        type: string
+                        description: >-
+                          The root of the Sapling commitment tree after applying
+                          this block
+                      tx:
+                        type: array
+                        items:
+                          type: string
+                          description: The transaction id's
+                      time:
+                        type: integer
+                        description: The block time in seconds since epoch (Jan 1 1970 GMT)
+                      nonce:
+                        type: string
+                        description: The nonce
+                      solution:
+                        type: string
+                        description: The solution
+                      bits:
+                        type: string
+                        description: The bits
+                      difficulty:
+                        type: number
+                        description: The difficulty
+                      chainwork:
+                        type: string
+                        description: The chainwork
+                      anchor:
+                        type: string
+                        description: Merkle root of note commitment tree
+                      valuePools:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              description: 'Protocol name of pool(sprout,sapling)'
+                            monitored:
+                              type: boolean
+                              description: Status of pool monitor
+                            chainValue:
+                              type: number
+                              description: Pool value of ZEL
+                            chainValueZat:
+                              type: integer
+                              description: Pool value of ZEL
+                            valueDelta:
+                              type: integer
+                              description: Delta value
+                            valueDeltaZat:
+                              type: integer
+                              description: Delta value
+                      previousblockhash:
+                        type: string
+                        description: The hash of the previous block
+                      nextblockhash:
+                        type: string
+                        description: The hash of the next block
+              example:
+                status: success
+                data:
+                  hash: >-
+                    0000008ac60c223e8f7d7ea458264ec308135bde7515ee1440a824ea76610b2d
+                  confirmations: 3
+                  size: 1891
+                  height: 588530
+                  version: 4
+                  merkleroot: >-
+                    28f7e9d0c29bf5fa404b28e1e6c2228d7e8f9a672d24dc9c9882dabd8fd47714
+                  finalsaplingroot: >-
+                    5144b7dcffa9a72d774e376baa38001d0f1dd760e435902b7af2f72461532c6d
+                  tx:
+                    - >-
+                      1ed830027683e98c5670981ee983860485fce5132f30d9b6e8e248789c52c55d
+                    - >-
+                      4e90720727aa79d29870447c1f15f9bd40058b7096eb66d4b9de8c6e945975bb
+                  time: 1588282383
+                  nonce: >-
+                    0229f5cc00000000000000000000000000000000000000000000000040060000
+                  solution: >-
+                    1b01d5b42dce5c5fea7f4a591c812d36ac938bcaf035bed4dc6328b8de555c4b0a5b3657d0ae1d5807e828b5e5e5a6dd057d0493
+                  bits: 1e00c837
+                  difficulty: 2618.622027119306
+                  chainwork: >-
+                    000000000000000000000000000000000000000000000000000029a0d2a05a8e
+                  anchor: >-
+                    e9585c5a63103a1dffea87286f28b0c649a9b481aa150ef4bb309a7e9d76b34e
+                  valuePools:
+                    - id: sprout
+                      monitored: true
+                      chainValue: 266554.25222433
+                      chainValueZat: 26655425222433
+                      valueDelta: 0
+                      valueDeltaZat: 0
+                    - id: sapling
+                      monitored: true
+                      chainValue: 2018046.78899491
+                      chainValueZat: 201804678899491
+                      valueDelta: -0.01711468
+                      valueDeltaZat: -1711468
+                  previousblockhash: >-
+                    00000057e8ef2fc394594f1f37d6f5ef7cc2ab4f2af3b6b3eaa14adb9310950b
+                  nextblockhash: >-
+                    000000196832b58171a331e684f5c3df019632749a3219bfb57569d0f7601a30                
+  /zelcash/getblockchaininfo:
+    get:
+      tags:
+        - ZelCash
+      summary: Blockchain info
+      description: >-
+        Returns an object containing various state info regarding block chain
+        processing. Note that when the chain tip is at the last block before a
+        network upgrade activation, consensus.chaintip != consensus.nextblock.
+        **PUBLIC**
+      operationId: getBlockchainInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      chain:
+                        type: string
+                        description: >-
+                          Current network name as defined in BIP70 (main, test,
+                          regtest)
+                      blocks:
+                        type: integer
+                        description: The current number of blocks processed in the server
+                      headers:
+                        type: integer
+                        description: The current number of headers we have validated
+                      bestblockhash:
+                        type: string
+                        description: The hash of the currently best block
+                      difficulty:
+                        type: number
+                        description: The current difficulty
+                      verificationprogress:
+                        type: number
+                        description: Estimate of verification progress
+                      chainwork:
+                        type: string
+                        description: 'Total amount of work in active chain, in hexadecimal'
+                      pruned:
+                        type: boolean
+                        description: True if chain has been pruned
+                      size_on_disk:
+                        type: integer
+                        description: The estimated size of the block and undo files on disk
+                      commitments:
+                        type: integer
+                        description: Number of commitments
+                      valuePools:
+                        type: array
+                        items:
+                          properties:
+                            id:
+                              type: string
+                              description: Name of pool
+                            monitored:
+                              type: boolean
+                              description: Monitor status
+                            chainValue:
+                              type: number
+                              description: Value of ZEL
+                            chainValueZat:
+                              type: integer
+                              description: Value of ZEL
+                      softforks:
+                        type: array
+                        items:
+                          properties:
+                            id:
+                              type: string
+                              description: Name of softfork
+                            version:
+                              type: integer
+                              description: Block version
+                            enforce:
+                              type: object
+                              properties:
+                                status:
+                                  type: boolean
+                                  description: True if threshold reached
+                                found:
+                                  type: integer
+                                  description: Number of blocks with the new version found
+                                required:
+                                  type: integer
+                                  description: Number of blocks required to trigger
+                                window:
+                                  type: integer
+                                  description: >-
+                                    Maximum size of examined window of recent
+                                    blocks
+                            reject:
+                              type: object
+                              properties:
+                                status:
+                                  type: boolean
+                                  description: True if threshold reached
+                                found:
+                                  type: integer
+                                  description: Number of blocks with the new version found
+                                required:
+                                  type: integer
+                                  description: Number of blocks required to trigger
+                                window:
+                                  type: integer
+                                  description: >-
+                                    Maximum size of examined window of recent
+                                    blocks
+                      upgrades:
+                        type: object
+                        properties:
+                          76b809bb:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: Name of upgrade
+                              activationheight:
+                                type: integer
+                                description: Activation block height
+                              status:
+                                type: string
+                                description: Status of upgrade
+                              info:
+                                type: string
+                                description: Additional info of upgrade
+                      consensus:
+                        type: object
+                        properties:
+                          chaintip:
+                            type: string
+                            description: Branch ID used to validate the current chain tip
+                          nextblock:
+                            type: string
+                            description: >-
+                              Branch ID that the next block will be validated
+                              under
+              example:
+                status: success
+                data:
+                  chain: main
+                  blocks: 590788
+                  headers: 590788
+                  bestblockhash: >-
+                    0000007c586f90cbba2ba9b8708bd9e7982ad1e7feb61a196312e1cc9510972f
+                  difficulty: 2864.222620571916
+                  verificationprogress: 0.9999987778641473
+                  chainwork: >-
+                    000000000000000000000000000000000000000000000000000029ac8cd1cf8c
+                  pruned: false
+                  size_on_disk: 3398677218
+                  commitments: 809048
+                  valuePools:
+                    - id: sprout
+                      monitored: true
+                      chainValue: 266554.25222433
+                      chainValueZat: 26655425222433
+                    - id: sapling
+                      monitored: true
+                      chainValue: 2020907.82312995
+                      chainValueZat: 202090782312995
+                  softforks:
+                    - id: bip34
+                      version: 2
+                      enforce:
+                        status: true
+                        found: 4000
+                        required: 750
+                        window: 4000
+                      reject:
+                        status: true
+                        found: 4000
+                        required: 950
+                        window: 4000
+                    - id: bip66
+                      version: 3
+                      enforce:
+                        status: true
+                        found: 4000
+                        required: 750
+                        window: 4000
+                      reject:
+                        status: true
+                        found: 4000
+                        required: 950
+                        window: 4000
+                    - id: bip65
+                      version: 4
+                      enforce:
+                        status: true
+                        found: 4000
+                        required: 750
+                        window: 4000
+                      reject:
+                        status: true
+                        found: 4000
+                        required: 950
+                        window: 4000
+                  upgrades:
+                    76b809bb:
+                      name: Kamata
+                      activationheight: 558000
+                      status: active
+                      info: 'Zel Kamata Upgrade, Deterministic ZelNodes and ZelFlux'
+                  consensus:
+                    chaintip: 76b809bb
+                    nextblock: 76b809bb
+  /zelcash/getblockcount:
+    get:
+      tags:
+        - ZelCash
+      summary: Current block count
+      description: Returns the number of blocks in the best valid block chain. **PUBLIC**
+      operationId: getBlockCount
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: integer
+                    description: Block count
+              example:
+                status: success
+                data: 590823
+  /zelcash/getblockhash:
+    get:
+      tags:
+        - ZelCash
+      summary: Get block's hash
+      description: Returns hash of block in best-block-chain at index provided. **PUBLIC**
+      operationId: getBlockHash
+      parameters:
+        - in: query
+          name: index
+          required: true
+          schema:
+            type: number
+          description: Block number to get hash of
+          example: '?index=590823'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Block hash
+              example:
+                status: success
+                data: >-
+                  000000234b617194f3faff69ee62f0dde0115f2007c3b42e38eaba80c786a5e5
+  /zelcash/getblockheader:
+    get:
+      tags:
+        - ZelCash
+      summary: Block header info
+      description: Returns an Object with information about blockheader. **PUBLIC**
+      operationId: getBlockHeader
+      parameters:
+        - in: query
+          name: hash
+          required: true
+          schema:
+            type: number
+          description: Block hash to get header info from
+          example: >-
+            ?hash=000000234b617194f3faff69ee62f0dde0115f2007c3b42e38eaba80c786a5e5
+        - in: query
+          name: verbose
+          schema:
+            default: true
+            type: boolean
+            enum:
+              - true
+              - false
+          description: |
+            If verbose is false, returns a string that is serialized,
+            hex-encoded data for blockheader 'hash'. If verbose is true, returns
+            an Object with information about blockheader hash. Example:
+            - `hash`=`<block hash>`&`verbose`=`true`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      hash:
+                        type: string
+                        description: Block hash
+                      confirmations:
+                        type: integer
+                        description: Number of confirmations
+                      height:
+                        type: integer
+                        description: Block height
+                      version:
+                        type: integer
+                        description: Block version
+                      merkleroot:
+                        type: string
+                        description: The merkle root
+                      finalsaplingroot:
+                        type: string
+                        description: >-
+                          The root of the Sapling commitment tree after applying
+                          this block
+                      time:
+                        type: integer
+                        description: The block time in seconds since epoch (Jan 1 1970 GMT)
+                      nonce:
+                        type: string
+                        description: The nonce
+                      solution:
+                        type: string
+                        description: The solution
+                      bits:
+                        type: string
+                        description: The bits
+                      difficulty:
+                        type: number
+                        description: The difficulty
+                      chainwork:
+                        type: string
+                        description: Chainwork hash
+                      previousblockhash:
+                        type: string
+                        description: Hash of previous block
+                      nextblockhash:
+                        type: string
+                        description: Hash of next block
+              example:
+                status: success
+                data:
+                  hash: >-
+                    000000234b617194f3faff69ee62f0dde0115f2007c3b42e38eaba80c786a5e5
+                  confirmations: 9
+                  height: 590823
+                  version: 4
+                  merkleroot: >-
+                    61d6664cb4e3575d4362f922316712fe647555c313ab6c4625bb368a93b40cf6
+                  finalsaplingroot: >-
+                    6cb83efd5da7b16b4ef0adf1ae285f96f9d95cd1becfc81421f77b12c56902d5
+                  time: 1588559331
+                  nonce: >-
+                    0000015f00000000000000000f00000000000000000000000000000091060078
+                  solution: >-
+                    0633eb663b294a0dfc52d5b0d395e1f227397a8bdcdf9f8e1d5a0b3031f95d9a85c2854e6abdba5f9f972456b73a2ab62ee01d02
+                  bits: 1e00bb4f
+                  difficulty: 2799.054701674626
+                  chainwork: >-
+                    000000000000000000000000000000000000000000000000000029acbb5b0dc9
+                  previousblockhash: >-
+                    00000099767337bdf22bdbb7354509a9ed760298facbdcd40339b96590f85e26
+                  nextblockhash: >-
+                    0000009370f976e1d8be1634d291832039803836e951804e965af9066e18bde7
+  /zelcash/getchaintips:
+    get:
+      tags:
+        - ZelCash
+      summary: List of known chain tips
+      description: >-
+        Return information about all known tips in the block tree, including the
+        main chain as well as orphaned branches. **PUBLIC**
+      operationId: getChainTips
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        height:
+                          type: integer
+                          description: Height of chain tip
+                        hash:
+                          type: string
+                          description: Block hash of the tip
+                        branchlen:
+                          type: integer
+                          description: >-
+                            Length of branch connecting the tip to the main
+                            chain (0 if main chain)
+                        status:
+                          type: string
+                          description: Status of the chain
+              example:
+                status: success
+                data:
+                  - height: 591079
+                    hash: >-
+                      0000006d4467655a996e7c6a4023fc6f99010a5474cf87eb08995cb66ca65312
+                    branchlen: 0
+                    status: active
+                  - height: 591062
+                    hash: >-
+                      000000aa6b44b3403e5623810c8193d87155444174841f7fc4b40256929eff1e
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 590420
+                    hash: >-
+                      0000002ee3a1bd1b4dcfbc6c025d133f325c6c8015cad3b9996df3c319162422
+                    branchlen: 1
+                    status: headers-only
+                  - height: 590237
+                    hash: >-
+                      00000053167551792a9e556813a021665c95dc8e41d0e2ee35287cc0df1e9a39
+                    branchlen: 1
+                    status: valid-headers
+                  - height: 573023
+                    hash: >-
+                      000000015b536301ce9335210590f0ceadc6ae081f2b228639c194cd4b88271d
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 567360
+                    hash: >-
+                      0000006656a0d8209a5c515f7f8967bb143d951cf8f3fed7c03d3cb0244e47ae
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 566803
+                    hash: >-
+                      0000001efb8e3485a385c12d1820645053082bf429413601deeb551d30be2786
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 559010
+                    hash: >-
+                      0000022ce968281284e2a503ce201ad55a8523d1f61f6309d84c917814ce382d
+                    branchlen: 19
+                    status: headers-only
+                  - height: 449023
+                    hash: >-
+                      0000005df6591ba59a041a88dfecd7dae6c00d95e210867d8de5d24538f73981
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 448329
+                    hash: >-
+                      00000042c175d0a58246f367012c429a3e7edc906a9fe75875ed239ef563a38c
+                    branchlen: 2
+                    status: valid-fork
+                  - height: 313888
+                    hash: >-
+                      00000016c58660e65feac88fbc40dd6ca3f34213de7648df716255fac99d3bff
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 309050
+                    hash: >-
+                      00000080b9a14c60174620f645f649e1b8bbfb40c2bdbedbf84f3dda7964f334
+                    branchlen: 3
+                    status: valid-fork
+                  - height: 287750
+                    hash: >-
+                      0000001e50fb6dd3b42f15c18f9b46958eb7a6649e2396c19157cb02cb11098d
+                    branchlen: 3
+                    status: valid-fork
+                  - height: 284893
+                    hash: >-
+                      0000006557265e2d68a78e5caf427fee238c6e137f4c9124254209a07cbb30b8
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 277682
+                    hash: >-
+                      000000278ca4049a8136aa4fa1e7a6b9c00b3e68505019d2976d7c66167c5142
+                    branchlen: 34
+                    status: valid-fork
+                  - height: 260586
+                    hash: >-
+                      00000006bec95249932f478f4db27bed24cf5d9b76c041914408af1392f29be1
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 260179
+                    hash: >-
+                      00000032788a700fbeef2e6383b424eceafc24a70346efbc2f62ee95cbcc9bfa
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 257167
+                    hash: >-
+                      000000276fa3e3557e6a0df594c3ea47477dab4626e0aed8c2964c428a1f7c3d
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 257125
+                    hash: >-
+                      0000004401ccecffe93f175b7c50f29611874e987d3206f005d55569fd3230ca
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 257081
+                    hash: >-
+                      0000001adc8175b757096f65628f77c9247f82defdb98813ab248e65a1cebc6e
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 254707
+                    hash: >-
+                      0000003cb3b61f89afa0864c1312ac75a97c3650c2026cda83e08a06c425d0de
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 253887
+                    hash: >-
+                      0000003a011c3fbb70f4216a14686012d89a2751cbd0c74053f81da91a9293a8
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 250987
+                    hash: >-
+                      00000007ecfee7a6d3bf783e86c56a251c4bd4cdc0258398b692a8f3fd9dbeed
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 250820
+                    hash: >-
+                      0000003262698472ae5b39955633527e8c8656e126ff90f94f2cb922cde8a9a0
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 250102
+                    hash: >-
+                      00000049f03f3402f094eee4c117072915f92fb352e87e0c59309096ebb877aa
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 249084
+                    hash: >-
+                      00000018432f23446500e0dcf39a02b59b3e8583f30c7329653d166c1deb3e85
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 248591
+                    hash: >-
+                      0000003d2b53e4899649ec2b259d9b6718cbe0e7d73cd0907b48d8f0b7341c11
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 248394
+                    hash: >-
+                      0000004445e61be219a7030c06db6c31eda0fa720b95740c1d85456b4dbff45e
+                    branchlen: 1
+                    status: valid-fork
+                  - height: 247501
+                    hash: >-
+                      000000640166be87a0d70d474389c934972ef0eca75977dae80e27a179fe16fc
+                    branchlen: 1
+                    status: valid-fork
+  /zelcash/getdifficulty:
+    get:
+      tags:
+        - ZelCash
+      summary: Proof of work difficulty
+      description: >-
+        Returns the proof-of-work difficulty as a multiple of the minimum
+        difficulty. **PUBLIC**
+      operationId: getDifficulty
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: number
+                    description: Proof of work difficulty as a multiple
+              example:
+                status: success
+                data: 2572.645186022886
+  /zelcash/getmempoolinfo:
+    get:
+      tags:
+        - ZelCash
+      summary: Memory pool info
+      description: Returns details on the active state of the TX memory pool. **PUBLIC**
+      operationId: getMempoolInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      size:
+                        type: integer
+                        description: Current tx count
+                      bytes:
+                        type: integer
+                        description: Sum of all tx sizes
+                      usage:
+                        type: integer
+                        description: Total memory usage for the mempool
+              example:
+                status: success
+                data:
+                  size: 0
+                  bytes: 0
+                  usage: 0
+  /zelcash/getrawmempool:
+    get:
+      tags:
+        - ZelCash
+      summary: Transaction ids in memory pool
+      description: >-
+        Returns all transaction ids in memory pool as a json array of string.
+        **PUBLIC**
+      operationId: getRawMemPool
+      parameters:
+        - in: query
+          name: verbose
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: |
+            True for a json object, false for array of transaction ids.
+            - `verbose`=`true`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      txid:
+                        type: object
+                        properties:
+                          size:
+                            type: integer
+                            description: Transaction size in bytes
+                          fee:
+                            type: integer
+                            description: Transaction fee in ZEL
+                          time:
+                            type: integer
+                            description: >-
+                              Local time transaction entered pool in seconds
+                              since 1 Jan 1970 GMT
+                          height:
+                            type: integer
+                            description: Block height when transaction entered pool
+                          startingpriority:
+                            type: integer
+                            description: Priority when transaction entered pool
+                          currentpriority:
+                            type: integer
+                            description: Transaction priority now
+                          depends:
+                            type: array
+                            items:
+                              type: string
+                              description: >-
+                                Unconfirmed transactions used as inputs for this
+                                transaction
+              example:
+                status: success
+                data:
+                  2c2a34b81eeba402270465d3dcc44d41ef31e4bf6cae5cc8e2aeea64d7fce829:
+                    size: 4284
+                    fee: 0.0001
+                    time: 1588593142
+                    height: 591102
+                    startingpriority: 10000000000000000
+                    currentpriority: 10000000000000000
+                    depends: []
+                  5fbb025ff8a6f632b02545e353e15992e389ccd12dab2771f2d96c53c3e2382a:
+                    size: 895
+                    fee: 0.0001
+                    time: 1588593155
+                    height: 591102
+                    startingpriority: 10000000000000000
+                    currentpriority: 10000000000000000
+                    depends: []
+                  afc2f6ff2b9a546a3e0c5ba951338043f9866f23ad53622c5cc3b97ae0c89281:
+                    size: 198
+                    fee: 0.0001
+                    time: 1588592875
+                    height: 591101
+                    startingpriority: 0
+                    currentpriority: 0
+                    depends: []
+                  0e99affa132cfea43ad7f31923a00a4cab1ace5e7343b0e40dad346d94138fb8:
+                    size: 198
+                    fee: 0.0001
+                    time: 1588593142
+                    height: 591101
+                    startingpriority: 0
+                    currentpriority: 0
+                    depends: []
+                  f2d51d5c678ea6a27670e3552b66adda606a43b57222ab6363ea0d2001c292c9:
+                    size: 1189
+                    fee: 0.0001
+                    time: 1588593018
+                    height: 591102
+                    startingpriority: 10000000000000000
+                    currentpriority: 10000000000000000
+                    depends: []
+                  5af1b85af6e0e58e1ac00c5a93c51e0a6da927cdf8f9f981159acdf55fb382d2:
+                    size: 2611
+                    fee: 0.0001
+                    time: 1588592924
+                    height: 591102
+                    startingpriority: 10000000000000000
+                    currentpriority: 10000000000000000
+                    depends: []
+  /zelcash/gettxout:
+    get:
+      tags:
+        - ZelCash
+      summary: Transaction IDs in memory pool
+      description: >-
+        Returns all transaction ids in memory pool as a json array of string.
+        **PUBLIC**
+      operationId: getTxOut
+      parameters:
+        - in: query
+          name: txid
+          required: true
+          schema:
+            type: string
+          description: The transaction id
+          example: >-
+            ?txid=9e3cdde1b7c92728a1200a988bb046028fe93b9f1e15cc370974f7201d3d3a94
+        - in: query
+          name: 'n'
+          required: true
+          schema:
+            type: number
+          description: Vout value
+          example: '?txid=...&n=1'
+        - in: query
+          name: includemempool
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: >
+            Whether to include the mempool. 
+
+
+            Example:
+
+            - `txid`=`<transaction id>`&`n`=`<vout
+            value>`&`includemempool`=`true`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      bestblock:
+                        type: string
+                        description: Block hash
+                      confirmations:
+                        type: integer
+                        description: The number of confirmations
+                      value:
+                        type: number
+                        description: The transaction value in ZEL
+                      scriptPubKey:
+                        type: object
+                        properties:
+                          asm:
+                            type: string
+                            description: Script public key
+                          hex:
+                            type: string
+                            description: Hex
+                          reqSigs:
+                            type: number
+                            description: Number of required signatures
+                          type:
+                            type: string
+                            description: 'The type, eg pubkeyhash'
+                          addresses:
+                            type: array
+                            items:
+                              type: string
+                      version:
+                        type: integer
+                        description: The version number
+                      coinbase:
+                        type: boolean
+                        description: Coinbase or not
+              example:
+                status: success
+                data:
+                  bestblock: >-
+                    0000001dca878efaa3ae059492bd108cd2e53708325f609f21ffb948f8769115
+                  confirmations: 9
+                  value: 9.375
+                  scriptPubkey:
+                    asm: >-
+                      OP_DUP OP_HASH160 961f695fbc075b7f99f0b45323206930340efc98
+                      OP_EQUALVERIFY OP_CHECKSIG
+                    hex: 76a914961f695fbc075b7f99f0b45323206930340efc9888ac
+                    reqSigs: 1
+                    type: pubkeyhash
+                    addresses:
+                      - t1XZNzdMMDZ4QPRD2a6hHWQ4Mog3HF9mCMp
+                  version: 4
+                  coinbase: true
+  /zelcash/gettxoutproof:
+    get:
+      tags:
+        - ZelCash
+      summary: Hex-encoded proof of transaction
+      description: >-
+        Returns a hex-encoded proof that "txid" was included in a block.
+        **PUBLIC**
+      operationId: getTxOutProof
+      parameters:
+        - in: query
+          name: txids
+          required: true
+          schema:
+            type: string
+          description: The transaction id or comma separated list of txids
+          example: >-
+            ?txids=9e3cdde1b7c92728a1200a988bb046028fe93b9f1e15cc370974f7201d3d3a94
+        - in: query
+          name: blockhash
+          schema:
+            type: string
+          description: 'If specified, looks for txid in the block with this hash'
+          example: >-
+            ?txids=....&blockhash=000000142fc5a382f6db5895faa7e9519721be67560cfd0c2171634d541bc38e
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: >-
+                      A string that is a serialized, hex-encoded data for the
+                      proof
+              example:
+                status: success
+                data: >-
+                  04000000e6f6eb7762f7970a06ad119590ba1882a30e290e3f6837cc64960f1b70000000fde035a9548fe35311b0212323eeeb9844c9ab093b24982d397fd94ab68f68725f44c0da150b3d68af0671dc272b007c4354a03d63298b00ad7700d4b818f70a4d0ab05eaca2001e0001b8750000000000000000000000000000000000000000000000003eae1205340a77b45fde07253220864115fe31c3a77f1e84b358edafad9929200de7c90f8d38878f423f9dc35266b6fd8280e56d3615b988540100000001fde035a9548fe35311b0212323eeeb9844c9ab093b24982d397fd94ab68f68720101
+  /zelcash/gettxoutsetinfo:
+    get:
+      tags:
+        - ZelCash
+      summary: Unspent transaction output set info
+      description: Returns statistics about the unspent transaction output set. **PUBLIC**
+      operationId: getTxOutSetInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      height:
+                        type: integer
+                        description: Current block
+                      bestblock:
+                        type: string
+                        description: Best block hash hex
+                      transactions:
+                        type: integer
+                        description: The number of transactions
+                      txouts:
+                        type: integer
+                        description: The number of output transactions
+                      bytes_serialized:
+                        type: integer
+                        description: The serialized size
+                      hash_serialized:
+                        type: string
+                        description: The serialized hash
+                      total_amount:
+                        type: number
+                        description: The total amount
+              example:
+                status: success
+                data:
+                  height: 591140
+                  bestblock: >-
+                    0000005b43e6418210b25804493880c9834c2ae969bceb53f579282e6e077427
+                  transactions: 320076
+                  txouts: 2626978
+                  bytes_serialized: 80210836
+                  hash_serialized: >-
+                    151a45f9f10274ebc622877355f6c64a5ae6a8561c186d2028cb32127d3bf093
+                  total_amount: 99020653.199865
+  /zelcash/verifytxoutproof:
+    get:
+      tags:
+        - ZelCash
+      summary: Verifies a proof
+      description: >-
+        Verifies that a proof points to a transaction in a block, returning the
+        transaction it commits to and throwing an RPC error if the block is not
+        in our best chain. PUBLIC
+      operationId: verifyTxOutProof
+      parameters:
+        - in: path
+          name: proof
+          required: true
+          schema:
+            type: string
+          description: The hex-encoded proof generated by gettxoutproof
+          example: >-
+            ?proof=04000000e6f6eb7762f7970a06ad119590ba1882a30e290e3f6837cc64960f1b70000000fde035a9548fe35311b0212323eeeb9844c9ab093b24982d397fd94ab68f68725f44c0da150b3d68af0671dc272b007c4354a03d63298b00ad7700d4b818f70a4d0ab05eaca2001e0001b8750000000000000000000000000000000000000000000000003eae1205340a77b45fde07253220864115fe31c3a77f1e84b358edafad9929200de7c90f8d38878f423f9dc35266b6fd8280e56d3615b988540100000001fde035a9548fe35311b0212323eeeb9844c9ab093b24982d397fd94ab68f68720101
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: string
+                      description: Txid
+              example:
+                status: success
+                data:
+                  - >-
+                    72688fb64ad97f392d98243b09abc94498ebee232321b01153e38f54a935e0fd
+  /zelcash/getblocksubsidy:
+    get:
+      tags:
+        - ZelCash
+      summary: Block reward
+      description: >-
+        Returns block subsidy reward, taking into account the mining slow start
+        of block at index provided. **PUBLIC**
+      operationId: getBlockSubsidy
+      parameters:
+        - in: query
+          name: height
+          schema:
+            type: string
+          description: >-
+            The block height. If not provided, defaults to the current height of
+            the chain.
+          example: '?height=575000'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      miner:
+                        type: integer
+                        description: The mining reward amount in ZEL
+              example:
+                status: success
+                data:
+                  miner: 150
+  /zelcash/getblocktemplate:
+    get:
+      tags:
+        - ZelCash
+      summary: Data to construct a block
+      description: It returns data needed to construct a block to work on. **PUBLIC**
+      operationId: getBlockTemplate
+      parameters:
+        - in: query
+          name: jsonrequestobject
+          description: >
+            If the request parameters include a 'mode' key, that is used
+
+            to explicitly select between the default template request or a
+
+            proposal. This must be set to "template" or omitted.
+
+
+            For the capabilities array of strings the following are the client
+            side supported features.
+
+            - `longpoll`
+
+            - `coinbasetxn`
+
+            - `coinbasevalue`
+
+            - `proposal`
+
+            - `serverlist`
+
+            - `workid`
+          schema:
+            type: object
+            properties:
+              mode:
+                type: string
+                description: >-
+                  If the request parameters include a 'mode' key, that is used
+                  to explicitly select between the default template request or a
+                  proposal. This must be set to "template" or omitted.
+              capabilities:
+                type: array
+                items:
+                  type: string
+                  description: |
+                    Client side supported feature.
+
+                    - longpoll
+                    - coinbasetxn
+                    - coinbasevalue
+                    - proposal
+                    - serverlist
+                    - workid
+          example:
+            mode: template
+            capabilities:
+              - proposal
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      capabilities:
+                        type: array
+                        items:
+                          type: string
+                      version:
+                        type: integer
+                        description: Version number
+                      previousblockhash:
+                        type: string
+                        description: Block hash of current highest block
+                      finalsaplingroothash:
+                        type: string
+                        description: Hash of the final sapling root
+                      transactions:
+                        type: array
+                        items:
+                          properties:
+                            data:
+                              type: string
+                              description: Transaction data encoded in hexadecimal
+                            hash:
+                              type: string
+                              description: Hash/id encoded in little-endian hexadecimal
+                            depends:
+                              type: array
+                              items:
+                                type: integer
+                                description: >-
+                                  Transactions before this one (by 1-based index
+                                  in transaction list) that must be present in
+                                  the final block if this one is
+                            fee:
+                              type: integer
+                              description: >-
+                                Difference in value between transaction inputs
+                                and outputs(in Satoshis); for coinbase
+                                transactions, this is a negative number of the
+                                collected block fees (ie, not including the
+                                block subsidy); if key is not present, fee is
+                                unknown and client must not assume there isn't
+                                one
+                            sigops:
+                              type: integer
+                              description: >-
+                                Total number of SigOps, as counted for purposes
+                                of the block limits; if key is not present,
+                                sigop count is unknown and clients must not
+                                assume there aren't any
+                            required:
+                              type: boolean
+                              description: >-
+                                If provided and true, this transaction must be
+                                in the final block
+                      coinbasetxn:
+                        type: object
+                        properties:
+                          data:
+                            type: string
+                            description: Transaction data encoded in hexadecimal
+                          hash:
+                            type: string
+                            description: Hash/id encoded in little-endian hexadecimal
+                          depends:
+                            type: array
+                            items:
+                              type: integer
+                              description: >-
+                                Transactions before this one (by 1-based index
+                                in transaction list) that must be present in the
+                                final block if this one is
+                          fee:
+                            type: integer
+                            description: >-
+                              Difference in value between transaction inputs and
+                              outputs(in Satoshis); for coinbase transactions,
+                              this is a negative number of the collected block
+                              fees (ie, not including the block subsidy); if key
+                              is not present, fee is unknown and client must not
+                              assume there isn't one
+                          sigops:
+                            type: integer
+                            description: >-
+                              Total number of SigOps, as counted for purposes of
+                              the block limits; if key is not present, sigop
+                              count is unknown and clients must not assume there
+                              aren't any
+                          required:
+                            type: boolean
+                            description: >-
+                              If provided and true, this transaction must be in
+                              the final block
+                      longpollid:
+                        type: string
+                        description: Long polling id
+                      target:
+                        type: string
+                        description: The hash target
+                      mintime:
+                        type: integer
+                        description: >-
+                          The minimum timestamp appropriate for the next block
+                          time in seconds since epoch (Jan 1 1970 GMT)
+                      mutable:
+                        type: array
+                        items:
+                          type: string
+                          description: >-
+                            A way the block template may be changed, e.g. time,
+                            transactions, prevblock
+                      noncerange:
+                        type: string
+                        description: A range of valid nonces
+                      sigoplimit:
+                        type: integer
+                        description: Limit of sigops in the blocks
+                      sizelimit:
+                        type: integer
+                        description: Limit of block size
+                      curtime:
+                        type: integer
+                        description: >-
+                          Current timestamp in seconds since epoch (Jan 1 1970
+                          GMT)
+                      bits:
+                        type: string
+                        description: Compressed target of next block
+                      height:
+                        type: integer
+                        description: The height of the next block
+                      basic_zelnode_address:
+                        type: string
+                        description: ZEL address
+                      basic_zelnode_payout:
+                        type: integer
+                        description: Amount
+                      super_zelnode_address:
+                        type: string
+                        description: ZEL address
+                      super_zelnode_payout:
+                        type: integer
+                        description: Amount
+                      bamf_zelnode_address:
+                        type: string
+                        description: ZEL address
+                      bamf_zelnode_payout:
+                        type: integer
+                        description: Amount
+              example:
+                status: success
+                data:
+                  capabilities:
+                    - proposal
+                  version: 4
+                  previousblockhash: >-
+                    000000658616bec155572e8f1f8373d32267238f1afaf3b93fdbf71706436417
+                  finalsaplingroothash: >-
+                    5cd6119b539920ae7b373b85cdcc2299b4701a046e51240dc9258ca0d0a5c918
+                  transactions:
+                    - data: >-
+                        050000000470561a8cf2d80e49eaed6d74782cc0c8a012a1d39a493d021a4ac50efe530a0400000000b068b05e010b68b05e010d39312e3233382e3130352e3330411b79e3112833b65ded5c5bf093a10086297eed5ec132c6627acecccd3368406fa83d9d5b6266639986e5a8670e4b0ae48ee1c4be9e607eaee4d2e8a8ca6815b578411b6f7121b06ae754770f9f9da616ed86ec71215e21ba7f483ebe1be8e49118e2722c8c45c89d751bf9c9c88f35c001a85bd17425b85167e960ca53ddce9cadafa4
+                      hash: >-
+                        1a4682d42a7c05054ab20f16c07a69cf93c53d790707988a961fc0aa2396d703
+                      depends: []
+                      fee: 0
+                      sigops: 0
+                    - data: >-
+                        0400008085202f89000170a8464f010000001976a91490ae1d0392cc0d77d8dc7ac22f2161a7fc011f7088ac00000000ee05090058ac464f0100000002c9a84df2ebfaceb5b781b29f5cccd926881f7fdc22a3569eb4e3f52ecb6a91b57e26214c732ebd7ff20e3a3da7a6c71f0a0fea30e7bf7400ea6273f49394e152dbf79084a25447231a1547f55fecacc09adf1e5efed5bb39bfd330f7d43b37397b4dd57a38810248488fbff354be64ca982ffc4aa5a20b0f2be9421b17be6687aa447958c4706f7a38d1b7f4c4a26cfb671f9b755cb70d1a925ebed84051abeb1e421234acbeb78591f11296859d41dcb824e929d15c4062a027f32f396cff3f91d98fc92b776b9640437e6e1ae74fe62ff27fef677a3b8c35a9b398b00eb6fb0f16fe6108c4ced2c8a76f0c760eb3275e9b66fd87605a181ae982688b5d93115315e79e59189ab7abd5f21525f7f89b879fe6d97dcd88937d26970c6b8513ecd6e736148ae3e03fc61f5f651923d5994fac65cf8efe9b44548ebe1431027ed875e4495ddbc2bf8421b5d387fa679692f2e1b4cca70ae06693d7bbf67448ac0fe02f160c52952c5493bc23f56cbac4a5279e72d9d39fea76ea702e1f02476f059ff80f11c1b39f805ddab1705e6e3933b12d85df7d609a785bbc74fc0b8db6447e26214c732ebd7ff20e3a3da7a6c71f0a0fea30e7bf7400ea6273f49394e1528a9a70138419184d99a375e03a2b35d675d571edbbada814c909c2477c808e62d7fb06cfab8d3819e4ffe8270208e13c308796c24c01495b6c3984fb9c65e25a855b41b1c31fb7a5290c8d0532be8e1348f02065c8155f187990fed839812b485fa843776329b833087aeab4c15707ceaa7d1bc798b01fe3560bc6cd1fce303e9469525ce9b058940801c5a710b8f3c4ac6249aa3be797a625efc5ff3c7ac40704f02eadf30e883104f5f4a1e287ecfda2806311fce153dab5122dcf63bc8c075a3a1e7684cabad686bbda1e156f062da0f787ad8a85588688159f0f8c0b7453a005cfe181e8aaf3e28776d1f7f7d5ab0b4e3e2f365f41ef89301c7c6278fc1b929120a3a20ee54fad064ff52b9a152badee46b0ad61370667bd0bb2b3dab34178d6232c12dfcf5f1a3413f0ea74474678b05fe20f3fa9d0bc57fda979dd5e0101dc6ccdc8380ce5db926cd06e2d7a7ccb972923aaec2f54573033c5548d9cc1db9b80d58723b2737685608b08fbc064c78143dc385036a505d2cef5933a45cb45886308fd5b762ee49d448264ef4f7908d79a6528443f0c290aecdcc4da843b6d7f5be18b395fba03d778545df324f06796afc84666ea838c320912aebf9905a13189cfd77002cd8f81d3b0c5fc37078e4e3916e0ed142dd35d0c30fd98bf0cbb9bc359c05c9b940d0724fff4d0a14d86c6d8fa7b76b580d5ead667e252512ab28740d817967aa73e425551d7d68b318d515b86f89c5e471036b8f020ad04de9730af2f07e9b2cf98c1261cfe895a92558971000b3b110055aca51d3cc63dd347b39ca73d415135e608684a685235a10834ac2354ebcf068f56ea6874d8373850e9cd01f25b92735a21a3333dcf89c838a00a1ee2e6023ab3adddce55ecdd69ce7c0ad4deb46be2ac90d35103f1cbf29bb926948728de0a9ccaee62b1657798b178ef4e3c3783f65fc22d464b7572167430c4aeda88a65741c2ed4346e278c092958e2ef4a95a36fb38559962a064b51b8d2a5118f86b2c0af87b9e30bdb59e818a9a4e10c6f5e90610f3ca5d49ab802b73236f8c4c4940b3eb324f891e29dcb52b7774301131ba9cd19c7b3e608688da6828512beeb765022efb33a18d1c06fa72be61d069031e8c9bae91adbfefce323aac658b0a5572d703d938c7ad47ddca2d4139dbd36ab562f6393aff333e556a275d763504360850b7729257f34f3f5a7ec0d2d00a9f923db937a1ea186f1a2aeab93a6f26a642d00aa89ac335a3a67404954f0b967bab5b7168db3b052e29ca37de47fe441ce528ba7d866db6d74a129897d117c5f425098b0c6dd5d6fc95fa70b0de00d6cd0a2e509625cfff8fe8e02f422fbb085536611a203b08415bfc3da6b4cfeea96eddbb1e9ff89d399f5a1172e19a1b67c30c22e3b9d636675ff05b40168b9e6adad1024af37bbc4545689fbe19ecf0c42c33d9c833bb84fdc191399327819e4086c14c99fcbf7d1d4bcf9a17049d50a584c5eaee2ac055a9d907e6c6dcfb71a99714b165a17d244e05fafe75c641941d566200566209bb8dd2ca677997c88253748ba43f8274ed79ba4bc8fd55bd218fff66a8d41e7e1380ee331bbfe8d0f4af30a6078436008a5d9ff677e0e33c3506f406ca4324d2b2dfd1222695dcbd551429833a56952786369c9ff6337f4f98cb74129ab521923d7fa02a19141deef9537a21f2c7d1aa97e6c77e57806eb85780efa659ba2b61c34e041eabf3f4aaece1cd9d652b91b2f4d84217c6ca323591b5de95e145dde6d2d3d07257b426806b009559b900604b3983b5d15cf6fce2372675fb4da3e47fd1578642462afc24d0e7e3bcc810ffb80c20aaa5ade917d988e033e70702016a33628b3ed0d52ad89f09
+                      hash: >-
+                        16c3b8b299ebe6185fc6a15f73741430a54fe628c33b4b25e84471b0d1dece61
+                      depends: []
+                      fee: 1000
+                      sigops: 1
+                  coinbasetxn:
+                    data: >-
+                      0400008085202f89010000000000000000000000000000000000000000000000000000000000000000ffffffff0503da050900ffffffff0468648d9e020000001976a914e210e47fc7fa4138c1dfd09358428e5421160c3b88aca0118721000000001976a9145bd98eb8a35c8c00cff5f0050ecd6e0ea4de66fd88ac601de137000000001976a9144dfad8f2081b808a2a9f9f16729e0a1fd5c6494b88ac80461c86000000001976a9144e5973f34e5cc452156126b541ca0c9bcaae91e488ac00000000000000000000000000000000000000
+                    hash: >-
+                      2aafbaa9024d62bb355951c877ca566b3883b182994297d7c581c365e5852702
+                    depends: []
+                    fee: 1000
+                    sigops: 4
+                    required: true
+                  longpollid: >-
+                    000000658616bec155572e8f1f8373d32267238f1afaf3b93fdbf7170643641717961
+                  target: >-
+                    000000c43b000000000000000000000000000000000000000000000000000000
+                  mintime: 1588618940
+                  mutable:
+                    - time
+                    - transactions
+                    - prevblock
+                  noncerange: 00000000ffffffff
+                  sigoplimit: 20000
+                  sizelimit: 2000000
+                  curtime: 1588619452
+                  bits: 1e00c43b
+                  height: 591322
+                  miner_reward: 11250001000
+                  basic_zelnode_address: t1SFG7xCkwWRP4tXhZrJmq7sWDFBniaNA16
+                  basic_zelnode_payout: 562500000
+                  super_zelnode_address: t1QyvYHuxfw6MQB1nsSvDdBPcsXqWsYKYDr
+                  super_zelnode_payout: 937500000
+                  bamf_zelnode_address: t1R1ssbaVXMZqbG8iwaD57xCS2w92pJefkw
+                  bamf_zelnode_payout: 2250000000
+  /zelcash/getlocalsolps:
+    get:
+      tags:
+        - ZelCash
+      summary: Average solutions per second
+      description: >-
+        Returns the average local solutions per second since this node was
+        started. **PUBLIC**
+      operationId: getLocalSolPs
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: integer
+                    description: Average sols per second
+              example:
+                status: success
+                data: 0
+  /zelcash/getmininginfo:
+    get:
+      tags:
+        - ZelCash
+      summary: Mining related info
+      description: Returns a json object containing mining-related information. **PUBLIC**
+      operationId: getMiningInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      blocks:
+                        type: integer
+                        description: The current block
+                      currentblocksize:
+                        type: integer
+                        description: The last block size
+                      currentblocktx:
+                        type: integer
+                        description: The last block transaction
+                      difficulty:
+                        type: number
+                        description: The current difficulty
+                      errors:
+                        type: string
+                        description: Current errors
+                      genproclimit:
+                        type: integer
+                        description: >-
+                          The processor limit for generation. -1 if no
+                          generation. (see getgenerate or setgenerate calls)
+                      localsolps:
+                        type: integer
+                        description: >-
+                          The average local solution rate in Sol/s since this
+                          node was started
+                      networksolps:
+                        type: integer
+                        description: The estimated network solution rate in Sol/s
+                      networkhashps:
+                        type: integer
+                        description: The estimated network hash rate in Hash/s
+                      pooledtx:
+                        type: integer
+                        description: The size of the mem pool
+                      testnet:
+                        type: boolean
+                        description: If using testnet or not
+                      chain:
+                        type: string
+                        description: >-
+                          Current network name as defined in BIP70 (main, test,
+                          regtest)
+                      generate:
+                        type: boolean
+                        description: >-
+                          If the generation is on or off (see getgenerate or
+                          setgenerate calls
+              example:
+                status: success
+                data:
+                  blocks: 591371
+                  currentblocksize: 1000
+                  currentblocktx: 0
+                  difficulty: 3214.481774201274
+                  errors: ''
+                  genproclimit: -1
+                  localsolps: 0
+                  networksolps: 188688
+                  networkhashps: 188688
+                  pooledtx: 78
+                  testnet: false
+                  chain: main
+                  generate: false
+  /zelcash/getnetworkhashps:
+    get:
+      tags:
+        - ZelCash
+      summary: Estimated network solutions
+      description: >-
+        Returns the estimated network solutions per second based on the last n
+        blocks. **PUBLIC**
+      operationId: getNetworkHashPs
+      parameters:
+        - in: query
+          name: blocks
+          schema:
+            default: 120
+            type: integer
+          description: >-
+            The number of blocks, or -1 for blocks over difficulty averaging
+            window.
+          example: '?blocks=200'
+        - in: query
+          name: height
+          schema:
+            default: 1
+            type: integer
+          description: To estimate at the time of the given height.
+          example: '?height=575000 or ?blocks=200&height=575000'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: integer
+                    description: Estimated network solutions per second
+              example:
+                status: success
+                data: 189503
+  /zelcash/getconnectioncount:
+    get:
+      tags:
+        - ZelCash
+      summary: Connection count
+      description: The peer connection count. **PUBLIC**
+      operationId: getConnectionCount
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: integer
+                    description: Connection count
+              example:
+                status: success
+                data: 22
+  /zelcash/getdeprecationinfo:
+    get:
+      tags:
+        - ZelCash
+      summary: Deprecation info
+      description: >-
+        Returns an object containing current version and deprecation block
+        height. Applicable only on mainnet. **PUBLIC**
+      operationId: getDeprecationInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      version:
+                        type: integer
+                        description: The server version
+                      subversion:
+                        type: string
+                        description: The server subversion string
+                      deprecationheight:
+                        type: integer
+                        description: >-
+                          The block height at which this version will deprecate
+                          and shut down
+              example:
+                status: success
+                data:
+                  version: 4000150
+                  subversion: '/MagicBean:4.0.1/'
+                  deprecationheight: 951040
+  /zelcash/getnettotals:
+    get:
+      tags:
+        - ZelCash
+      summary: Network traffic info
+      description: >-
+        Returns information about network traffic, including bytes in, bytes
+        out, and current time. **PUBLIC**
+      operationId: getNetTotals
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      totalbytesrecv:
+                        type: integer
+                        description: Total bytes received
+                      totalbytessent:
+                        type: integer
+                        description: Total bytes sent
+                      timemillis:
+                        type: integer
+                        description: Total cpu time
+              example:
+                status: success
+                data:
+                  totalbytesrecv: 27003767
+                  totalbytessent: 115073751
+                  timemillis: 1588626897371
+  /zelcash/getnetworkinfo:
+    get:
+      tags:
+        - ZelCash
+      summary: Info regarding P2P network
+      description: >-
+        Returns an object containing various state info regarding P2P
+        networking. **PUBLIC**
+      operationId: getNetworkInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      version:
+                        type: integer
+                        description: The server version
+                      subversion:
+                        type: string
+                        description: The server subversion string
+                      protocolversion:
+                        type: integer
+                        description: The protocol version
+                      localservices:
+                        type: string
+                        description: The services we offer to the network
+                      timeoffset:
+                        type: integer
+                        description: The time offset
+                      connections:
+                        type: integer
+                        description: Number of connections
+                      networks:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: 'Network (ipv4, ipv6 or onion)'
+                            limited:
+                              type: boolean
+                              description: Is the network limited using -onlynet?
+                            reachable:
+                              type: boolean
+                              description: Is the network reachable?
+                            proxy:
+                              type: string
+                              description: >-
+                                The proxy that is used for this network, or
+                                empty if none
+                            proxy_randomize_credentials:
+                              type: boolean
+                              description: Does proxy randomize credentials?
+                      relayfee:
+                        type: number
+                        description: Minimum relay fee for non-free transactions in ZEL/kB
+                      localaddresses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            address:
+                              type: string
+                              description: Network addess
+                            port:
+                              type: integer
+                              description: Network port
+                            score:
+                              type: integer
+                              description: Relative score
+                      warnings:
+                        type: string
+                        description: Any network warnings (such as alert messages)
+              example:
+                status: success
+                data:
+                  version: 4000150
+                  subversion: '/MagicBean:4.0.1/'
+                  protocolversion: 170016
+                  localservices: 5
+                  timeoffset: 0
+                  connections: 28
+                  networks:
+                    - name: ipv4
+                      limited: false
+                      reachable: true
+                      proxy: ''
+                      proxy_randomize_credentials: false
+                    - name: ipv6
+                      limited: false
+                      reachable: true
+                      proxy: ''
+                      proxy_randomize_credentials: false
+                    - name: onion
+                      limited: true
+                      reachable: false
+                      proxy: ''
+                      proxy_randomize_credentials: false
+                  relayfee: 0.000001
+                  localaddresses:
+                    - address: 96.30.196.88
+                      port: 16125
+                      score: 1433
+                  warnings: ''
+  /zelcash/getpeerinfo:
+    get:
+      tags:
+        - ZelCash
+      summary: Peer info
+      description: >-
+        Returns data about each connected network node as a json array of
+        objects. **PUBLIC**
+      operationId: getPeerInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          description: Peer index
+                        addr:
+                          type: string
+                          description: Ip address and port of the peer
+                        addrlocal:
+                          type: string
+                          description: Local address
+                        services:
+                          type: string
+                          description: The services offered
+                        lastsend:
+                          type: integer
+                          description: >-
+                            The time in seconds since epoch (Jan 1 1970 GMT) of
+                            the last send
+                        lastrecv:
+                          type: integer
+                          description: >-
+                            The time in seconds since epoch (Jan 1 1970 GMT) of
+                            the last receive
+                        bytessent:
+                          type: integer
+                          description: Total bytes sent
+                        bytesrecv:
+                          type: integer
+                          description: Total bytes recieved
+                        conntime:
+                          type: integer
+                          description: >-
+                            The connection time in seconds since epoch (Jan 1
+                            1970 GMT)
+                        timeoffset:
+                          type: integer
+                          description: The time offset in seconds
+                        pingtime:
+                          type: number
+                          description: Png time
+                        version:
+                          type: integer
+                          description: The peer version
+                        subver:
+                          type: string
+                          description: The string version
+                        inbound:
+                          type: boolean
+                          description: Inbound (true) or Outbound (false)
+                        startingheight:
+                          type: integer
+                          description: The starting height (block) of the peer
+                        banscore:
+                          type: integer
+                          description: The ban score
+                        synced_headers:
+                          type: integer
+                          description: The last header we have in common with this peer
+                        synced_blocks:
+                          type: integer
+                          description: The last block we have in common with this peer
+                        inflight:
+                          type: array
+                          items:
+                            type: integer
+                            description: >-
+                              The heights of blocks we're currently asking from
+                              this peer
+                        whitelisted:
+                          type: boolean
+                          description: Is peer whitelisted?
+              example:
+                status: success
+                data:
+                  - id: 741
+                    addr: '159.65.254.184:16125'
+                    addrlocal: '96.30.196.88:46270'
+                    services: 5
+                    lastsend: 1588677108
+                    lastrecv: 1588677108
+                    bytessent: 1955685
+                    bytesrecv: 2801490
+                    conntime: 1588497832
+                    timeoffset: 0
+                    pingtime: 0.019793
+                    version: 170016
+                    subver: '/MagicBean:4.0.1(bitcore)/'
+                    inbound: false
+                    startingheight: 590308
+                    banscore: 90
+                    synced_headers: 591801
+                    synced_blocks: 591801
+                    inflight: []
+                    whitelisted: false
+                  - id: 847
+                    addr: '116.203.52.168:16125'
+                    addrlocal: '96.30.196.88:58594'
+                    services: 5
+                    lastsend: 1588677081
+                    lastrecv: 1588677081
+                    bytessent: 1281133
+                    bytesrecv: 2176814
+                    conntime: 1588519342
+                    timeoffset: 0
+                    pingtime: 0.107897
+                    version: 170016
+                    subver: '/MagicBean:4.0.1(bitcore)/'
+                    inbound: false
+                    startingheight: 590491
+                    banscore: 90
+                    synced_headers: 591801
+                    synced_blocks: 591801
+                    inflight: []
+                    whitelisted: false
+  /zelcash/listbanned:
+    get:
+      tags:
+        - ZelCash
+      summary: Ban list
+      description: List all banned IPs/Subnets. **PUBLIC**
+      operationId: listBanned
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        address:
+                          type: string
+                          description: Ip/subnet
+                        banned_until:
+                          type: integer
+                          description: The time in seconds since epoch (Jan 1 1970 GMT)
+              example:
+                status: success
+                data:
+                  - address: 5.189.130.70/255.255.255.255
+                    banned_until: 1588737697
+                  - address: 46.4.142.199/255.255.255.255
+                    banned_until: 1588474952
+                  - address: 62.171.153.25/255.255.255.255
+                    banned_until: 1588737698
+                  - address: 62.171.166.168/255.255.255.255
+                    banned_until: 1588745015
+  /zelcash/createrawtransaction:
+    post:
+      tags:
+        - ZelCash
+      summary: Create hex-encoded raw transaction
+      description: >-
+        Create a transaction spending the given inputs and sending to the given
+        addresses. Returns hex-encoded raw transaction. Note that the
+        transaction's inputs are not signed, and it is not stored in the wallet
+        or transmitted to the network. **PUBLIC**
+      operationId: createRawTransactionPost
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                transactions:
+                  type: array
+                  items:
+                    type: object
+                    description: Objects pertaining to the transaction
+                    properties:
+                      txid:
+                        type: string
+                        description: The transaction id
+                      vout:
+                        type: integer
+                        description: The output index
+                      sequence:
+                        type: integer
+                        description: Sequence number (optional)
+                addresses:
+                  type: object
+                  description: Object with addresses as keys and amounts as values
+                locktime:
+                  type: integer
+                  default: 0
+                  description: >-
+                    Raw locktime. Non-0 value also locktime-activates inputs.
+                    (optional)
+                expiryheight:
+                  type: integer
+                  default: Nextblockheight+20
+                  description: Expiry height of transaction (optional)
+            example:
+              transactions:
+                - txid: >-
+                    224225b04fd54e8653e7cd4440dd4596aab6eff8be8686bacfad9213172da4369f
+                  vout: 0
+              addresses:
+                t1JKRwXGfKTGfPV1z48rvoLyabk31z3xwHa: 112.5
+              locktime: 10
+              expiryheight: 595000
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Hex string of the transaction
+              example:
+                status: success
+                data: >-
+                  0400008085202f89019f36a42d171392adcfba8686bef8efb6aa9645dd4044cde753864ed54fb025420000000000feffffff0180608d9e020000001976a91404e2699cec5f44280540fb752c7660aa3ba857cc88ac01000000fb0809000000000000000000000000
+    get:
+      tags:
+        - ZelCash
+      summary: Create hex-encoded raw transaction
+      description: >-
+        Create a transaction spending the given inputs and sending to the given
+        addresses. Returns hex-encoded raw transaction. Note that the
+        transaction's inputs are not signed, and it is not stored in the wallet
+        or transmitted to the network. **PUBLIC**
+      operationId: createRawTransaction
+      parameters:
+        - in: query
+          name: transactions
+          description: >
+            Array of objects key/value pairs:
+
+            - `txid`: `<transaction id>` (required)
+
+            - `vout`: `<output index>` (required)
+
+            - `sequence`: `<sequence number>` (optional)
+
+
+            Url encoded example: 
+
+            -
+            `transactions`=`%5B%7B%22txid%22%3A%224225b04fd54e8653e7cd4440dd4596aab6eff8be8686bacfad9213172da4369f%22%2C%22vout%22%3A0%7D%5D`
+          required: true
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                txid:
+                  type: string
+                  description: Txid to use to get the raw data
+                vout:
+                  type: integer
+                  description: The output number
+                sequence:
+                  type: integer
+                  description: The sequence number (optional)
+        - in: query
+          name: addresses
+          required: true
+          description: >
+            The key is the Zelcash address, the value is the ZEL amount. Url
+            encoded example:
+
+            -
+            addresses=%7B%22t1JKRwXGfKTGfPV1z48rvoLyabk31z3xwHa%22%3A112.50000000%7D
+          schema:
+            type: object
+            properties:
+              address:
+                type: string
+          example:
+            transactions:
+              - txid: >-
+                  224225b04fd54e8653e7cd4440dd4596aab6eff8be8686bacfad9213172da4369f
+                vout: 1
+            addresses:
+              t1JKRwXGfKTGfPV1z48rvoLyabk31z3xwHa: 112.5
+        - in: query
+          name: locktime
+          schema:
+            default: 0
+            type: number
+          description: Raw locktime. Non-0 value also locktime-activates inputs.
+          example: '?transactions=...&addresses=...&locktime=10'
+        - in: query
+          name: expiryheight
+          schema:
+            default: nextblockheight+20
+            type: string
+          description: Expiry height of transaction (if Overwinter is active).
+          example: '?transactions=...&addresses=...&expiryheight=595000'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Hex string of the transaction
+              example:
+                status: success
+                data: >-
+                  0400008085202f89019f36a42d171392adcfba8686bef8efb6aa9645dd4044cde753864ed54fb025420000000000feffffff0180608d9e020000001976a91404e2699cec5f44280540fb752c7660aa3ba857cc88ac01000000fb0809000000000000000000000000
+  /zelcash/decoderawtransaction:
+    post:
+      tags:
+        - ZelCash
+      summary: Decoded info of the hex-encoded transaction
+      description: >-
+        Return a JSON object representing the serialized, hex-encoded
+        transaction. **PUBLIC**
+      operationId: decodeRawTransactionPost
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                hexstring:
+                  type: string
+                  description: Hex-encoded transaction
+            example:
+              hexstring: >-
+                0400008085202f89019f36a42d171392adcfba8686bef8efb6aa9645dd4044cde753864ed54fb025420000000000feffffff0180608d9e020000001976a91404e2699cec5f44280540fb752c7660aa3ba857cc88ac01000000fb0809000000000000000000000000
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/decoderawtransaction'
+              example:
+                status: success
+                data:
+                  txid: >-
+                    03c228785451de39ce396c85168c979a439dcb2037f92d0a57de81e6b1c9f3a4
+                  version: 4
+                  overwintered: true
+                  versiongroupid: 892f2085
+                  locktime: 1
+                  expiryheight: 592123
+                  vin:
+                    - txid: >-
+                        4225b04fd54e8653e7cd4440dd4596aab6eff8be8686bacfad9213172da4369f
+                      vout: 0
+                      scriptSig:
+                        asm: ''
+                        hex: ''
+                      sequence: 4294967295
+                  vout:
+                    - value: 112.5001
+                      valueZat: 11250010000
+                      valueSat: 11250010000
+                      'n': 0
+                      scriptPubKey:
+                        asm: >-
+                          OP_DUP OP_HASH160
+                          04e2699cec5f44280540fb752c7660aa3ba857cc
+                          OP_EQUALVERIFY OP_CHECKSIG
+                        hex: 76a91404e2699cec5f44280540fb752c7660aa3ba857cc88ac
+                        reqSigs: 1
+                        type: pubkeyhash
+                        addresses:
+                          - t1JKRwXGfKTGfPV1z48rvoLyabk31z3xwHa
+                  vJoinSplit: []
+                  valueBalance: 0
+                  valueBalanceZat: 0
+                  vShieldedSpend: []
+                  vShieldedOutput: []
+    get:
+      tags:
+        - ZelCash
+      summary: Decoded info of the hex-encoded transaction
+      description: >-
+        Return a JSON object representing the serialized, hex-encoded
+        transaction. **PUBLIC**
+      operationId: decodeRawTransaction
+      parameters:
+        - in: query
+          name: hexstring
+          required: true
+          schema:
+            type: string
+          description: Hex-encoded transaction
+          example: >-
+            ?hexstring=0400008085202f89019f36a42d171392adcfba8686bef8efb6aa9645dd4044cde753864ed54fb025420000000000feffffff0180608d9e020000001976a91404e2699cec5f44280540fb752c7660aa3ba857cc88ac01000000fb0809000000000000000000000000
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/decoderawtransaction'
+              example:
+                status: success
+                data:
+                  txid: >-
+                    03c228785451de39ce396c85168c979a439dcb2037f92d0a57de81e6b1c9f3a4
+                  version: 4
+                  overwintered: true
+                  versiongroupid: 892f2085
+                  locktime: 1
+                  expiryheight: 592123
+                  vin:
+                    - txid: >-
+                        4225b04fd54e8653e7cd4440dd4596aab6eff8be8686bacfad9213172da4369f
+                      vout: 0
+                      scriptSig:
+                        asm: ''
+                        hex: ''
+                      sequence: 4294967295
+                  vout:
+                    - value: 112.5001
+                      valueZat: 11250010000
+                      valueSat: 11250010000
+                      'n': 0
+                      scriptPubKey:
+                        asm: >-
+                          OP_DUP OP_HASH160
+                          04e2699cec5f44280540fb752c7660aa3ba857cc
+                          OP_EQUALVERIFY OP_CHECKSIG
+                        hex: 76a91404e2699cec5f44280540fb752c7660aa3ba857cc88ac
+                        reqSigs: 1
+                        type: pubkeyhash
+                        addresses:
+                          - t1JKRwXGfKTGfPV1z48rvoLyabk31z3xwHa
+                  vJoinSplit: []
+                  valueBalance: 0
+                  valueBalanceZat: 0
+                  vShieldedSpend: []
+                  vShieldedOutput: []
+  /zelcash/decodescript:
+    post:
+      tags:
+        - ZelCash
+      summary: Decode hex script
+      description: Decode a hex-encoded script. **PUBLIC**
+      operationId: decodeScriptPost
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                hex:
+                  type: string
+                  description: Hex-encoded transaction
+            example:
+              hex: 76a91404e2699cec5f44280540fb752c7660aa3ba857cc88ac
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/decodescript'
+              example:
+                status: success
+                data:
+                  asm: >-
+                    OP_DUP OP_HASH160 04e2699cec5f44280540fb752c7660aa3ba857cc
+                    OP_EQUALVERIFY OP_CHECKSIG
+                  reqSigs: 1
+                  type: pubkeyhash
+                  addresses:
+                    - t1JKRwXGfKTGfPV1z48rvoLyabk31z3xwHa
+                  p2sh: t3U9WHvndqz58mHBX168iveW5E4xMdeBkWw
+    get:
+      tags:
+        - ZelCash
+      summary: Decode hex script
+      description: Decode a hex-encoded script. **PUBLIC**
+      operationId: decodeScript
+      parameters:
+        - in: query
+          name: hex
+          required: true
+          schema:
+            type: string
+          description: Hex-encoded transaction
+          example: '?hex=76a91404e2699cec5f44280540fb752c7660aa3ba857cc88ac'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/decodescript'
+              example:
+                status: success
+                data:
+                  asm: >-
+                    OP_DUP OP_HASH160 04e2699cec5f44280540fb752c7660aa3ba857cc
+                    OP_EQUALVERIFY OP_CHECKSIG
+                  reqSigs: 1
+                  type: pubkeyhash
+                  addresses:
+                    - t1JKRwXGfKTGfPV1z48rvoLyabk31z3xwHa
+                  p2sh: t3U9WHvndqz58mHBX168iveW5E4xMdeBkWw
+  /zelcash/getrawtransaction:
+    get:
+      tags:
+        - ZelCash
+      summary: Get raw transaction data
+      description: >-
+        Gets raw transaction data from the txid, if verbose=0 then only hex data
+        of transaction is shown, if verbose=1 then it will return with object of
+        info of txid. **PUBLIC**
+      operationId: getRawTransaction
+      parameters:
+        - in: query
+          name: txid
+          required: true
+          schema:
+            type: string
+          description: Txid to get raw tx data from
+          example: >-
+            ?txid=1ed830027683e98c5670981ee983860485fce5132f30d9b6e8e248789c52c55d
+        - in: query
+          name: verbose
+          schema:
+            default: 0
+            type: number
+          description: >-
+            If verbose is not set or at 0 only hex-encoded data for the txid
+            will return but if set at 1 it will return an object with info of
+            the txid.
+          example: '?txid=...&verbose=1'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      hex:
+                        type: string
+                        description: 'The serialized, hex-encoded data for ''txid'''
+                      txid:
+                        type: string
+                        description: The transaction id (same as provided)
+                      version:
+                        type: number
+                        description: The version
+                      overwintered:
+                        type: boolean
+                        description: The Overwintered flag
+                      versiongroupid:
+                        type: string
+                        description: The version group id
+                      locktime:
+                        type: number
+                        description: The lock time
+                      expiryheight:
+                        type: number
+                        description: Last valid block height for mining transaction
+                      vin:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            coinbase:
+                              type: string
+                              description: Coinbase hash
+                            sequence:
+                              type: number
+                              description: The script sequence number
+                      vout:
+                        $ref: '#/components/schemas/vout'
+                      vJoinSplit:
+                        $ref: '#/components/schemas/joinsplit'
+                      valueBalance:
+                        type: number
+                        description: The balance value of ZEL
+                      valueBalanceZat:
+                        type: integer
+                        description: The balance value of ZEL
+                      vShieldedSpend:
+                        $ref: '#/components/schemas/shieldedspend'
+                      vShieldedOutput:
+                        $ref: '#/components/schemas/shieldedoutput'
+                      bindingSig:
+                        type: string
+                        description: Binding signature
+                      blockhash:
+                        type: string
+                        description: The block hash
+                      height:
+                        type: integer
+                        description: Block height
+                      confirmations:
+                        type: integer
+                        description: The confirmations
+                      time:
+                        type: integer
+                        description: >-
+                          The transaction time in seconds since epoch (Jan 1
+                          1970 GMT)
+                      blocktime:
+                        type: integer
+                        description: The block time in seconds since epoch (Jan 1 1970 GMT)
+              example:
+                status: success
+                data:
+                  hex: >-
+                    0400008085202f89010000000000000000000000000000000000000000000000000000000000000000ffffffff2003f2fa0800324d696e6572732068747470733a2f2f326d696e6572732e636f6dffffffff0490878d9e020000001976a91404e2699cec5f44280540fb752c7660aa3ba857cc88aca0118721000000001976a914a6886f088ddd5aa3d6027b6d826f912a7ba1c6b788ac601de137000000001976a9145227c99503eae5f10a7373a2b0f385c5cc01459a88ac80461c86000000001976a914c0cf057a7735c07aafb9b3d1ff158a775dffa82e88ac00000000000000000000000000000000000000
+                  txid: >-
+                    1ed830027683e98c5670981ee983860485fce5132f30d9b6e8e248789c52c55d
+                  version: 4
+                  overwintered: true
+                  versiongroupid: 892f2085
+                  locktime: 0
+                  expiryheight: 0
+                  vin:
+                    - coinbase: >-
+                        03f2fa0800324d696e6572732068747470733a2f2f326d696e6572732e636f6d
+                      sequence: 4294967295
+                  vout:
+                    - value: 112.5001
+                      valueZat: 11250010000
+                      valueSat: 11250010000
+                      'n': 0
+                      scriptPubKey:
+                        asm: >-
+                          OP_DUP OP_HASH160
+                          04e2699cec5f44280540fb752c7660aa3ba857cc
+                          OP_EQUALVERIFY OP_CHECKSIG
+                        hex: 76a91404e2699cec5f44280540fb752c7660aa3ba857cc88ac
+                        reqSigs: 1
+                        type: pubkeyhash
+                        addresses:
+                          - t1JKRwXGfKTGfPV1z48rvoLyabk31z3xwHa
+                    - value: 5.625
+                      valueZat: 562500000
+                      valueSat: 562500000
+                      'n': 1
+                      scriptPubKey:
+                        asm: >-
+                          OP_DUP OP_HASH160
+                          a6886f088ddd5aa3d6027b6d826f912a7ba1c6b7
+                          OP_EQUALVERIFY OP_CHECKSIG
+                        hex: 76a914a6886f088ddd5aa3d6027b6d826f912a7ba1c6b788ac
+                        reqSigs: 1
+                        type: pubkeyhash
+                        addresses:
+                          - t1Z49cm5Wi5RaojyLopqCpjJpK18RXM1asy
+                    - value: 9.375
+                      valueZat: 937500000
+                      valueSat: 937500000
+                      'n': 2
+                      scriptPubKey:
+                        asm: >-
+                          OP_DUP OP_HASH160
+                          5227c99503eae5f10a7373a2b0f385c5cc01459a
+                          OP_EQUALVERIFY OP_CHECKSIG
+                        hex: 76a914c0cf057a7735c07aafb9b3d1ff158a775dffa82e88ac
+                        reqSigs: 1
+                        type: pubkeyhash
+                        addresses:
+                          - t1RN15YYt5vZqUoU3PGNCtnY1eDKRUs3pkE
+                    - value: 22.5
+                      valueZat: 2250000000
+                      valueSat: 2250000000
+                      'n': 3
+                      scriptPubKey:
+                        asm: >-
+                          OP_DUP OP_HASH160
+                          c0cf057a7735c07aafb9b3d1ff158a775dffa82e
+                          OP_EQUALVERIFY OP_CHECKSIG
+                        hex: 76a914c0cf057a7735c07aafb9b3d1ff158a775dffa82e88ac
+                        reqSigs: 1
+                        type: pubkeyhash
+                        addresses:
+                          - t1bT5kGPGLzkwkGxVtC96Toxv3AEm86AbAF
+                  vJoinSplit: []
+                  valueBalance: 0
+                  valueBalanceZat: 0
+                  vShieldedSpend: []
+                  vShieldedOutput: []
+                  blockhash: >-
+                    0000008ac60c223e8f7d7ea458264ec308135bde7515ee1440a824ea76610b2d
+                  height: 588530
+                  confirmations: 403
+                  time: 1588282383
+                  blocktime: 1588282383
+  /zelcash/fundrawtransaction:
+    post:
+      tags:
+        - ZelCash
+      summary: Add inputs to a transaction
+      description: >-
+        Add inputs to a transaction until it has enough in value to meet its out
+        value. This will not modify existing inputs, and will add one change
+        output to the outputs. Note that inputs which were signed may need to be
+        resigned after completion since in/outputs have been added. The inputs
+        added will not be signed, use signrawtransaction for that. **PUBLIC**
+      operationId: fundRawTransactionPost
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                hex:
+                  type: string
+                  description: Hex-encoded transaction
+            example:
+              hexstring: >-
+                0400008085202f8901ab719872dfea1b4f594049722a92efafa4695322d2c08654aafe98c6546066360000000000ffffffff0140420f00000000001976a9142e5db3157a9783c6208019323f2c3a02610826a988ac00000000a60a09000000000000000000000000
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/fundrawtransaction'
+              example:
+                status: success
+                data:
+                  hex: >-
+                    0400008085202f8901ab719872dfea1b4f594049722a92efafa4695322d2c08654aafe98c6546066360000000000ffffffff0240420f00000000001976a9142e5db3157a9783c6208019323f2c3a02610826a988accb9de605000000001976a91496b7e557775f02097632e7f4a4e6157a77ec6a8088ac00000000a60a09000000000000000000000000
+                  changepos: 1
+                  fee: 0.00000245
+    get:
+      tags:
+        - ZelCash
+      summary: Add inputs to a transaction
+      description: >-
+        Add inputs to a transaction until it has enough in value to meet its out
+        value. This will not modify existing inputs, and will add one change
+        output to the outputs. Note that inputs which were signed may need to be
+        resigned after completion since in/outputs have been added. The inputs
+        added will not be signed, use signrawtransaction for that. **PUBLIC**
+      operationId: fundRawTransaction
+      parameters:
+        - in: query
+          name: hexstring
+          required: true
+          schema:
+            type: string
+          description: Hex string of raw transaction
+          example: >-
+            ?hexstring=0400008085202f8901ab719872dfea1b4f594049722a92efafa4695322d2c08654aafe98c6546066360000000000ffffffff0140420f00000000001976a9142e5db3157a9783c6208019323f2c3a02610826a988ac00000000a60a09000000000000000000000000
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/fundrawtransaction'
+              example:
+                status: success
+                data:
+                  hex: >-
+                    0400008085202f8901ab719872dfea1b4f594049722a92efafa4695322d2c08654aafe98c6546066360000000000ffffffff0240420f00000000001976a9142e5db3157a9783c6208019323f2c3a02610826a988accb9de605000000001976a91496b7e557775f02097632e7f4a4e6157a77ec6a8088ac00000000a60a09000000000000000000000000
+                  changepos: 1
+                  fee: 0.00000245
+  /zelcash/sendrawtransaction:
+    post:
+      tags:
+        - ZelCash
+      summary: Send raw transaction
+      description: >-
+        Submits raw transaction (serialized, hex-encoded) to local node and
+        network. Also see createrawtransaction and signrawtransaction calls.
+        **PUBLIC**
+      operationId: sendRawTransactionPost
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                hexstring:
+                  type: string
+                  description: Hex-encoded transaction
+                allowhighfees:
+                  type: boolean
+                  default: false
+                  description: Allow high fees (optional)
+            example:
+              hexstring: >-
+                0400008085202f8901ab719872dfea1b4f594049722a92efafa4695322d2c08654aafe98c654606636000000006b483045022100e5f02014419280a5c1ed1f94513e8e2bee83f6341863b304fe093dea897f4aa20220022a6e6004dbf1305197f4053bd9dd59e21abd23a31d0188d079eb72cab84e990121036b6a136ce869a0b400548a9126f06d96181ee974ff1c7f5a5e54e39b7f66be05ffffffff0140420f00000000001976a9142e5db3157a9783c6208019323f2c3a02610826a988ac00000000a60a09000000000000000000000000
+              allowhighfees: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: The transaction hash in hex
+              example:
+                status: success
+                data: >-
+                  381bfe56a049208ff90356153f024395b7a74b5ec470d639dd7e6ffa4487b2fe
+    get:
+      tags:
+        - ZelCash
+      summary: Send raw transaction
+      description: >-
+        Submits raw transaction (serialized, hex-encoded) to local node and
+        network. Also see createrawtransaction and signrawtransaction calls.
+        **PUBLIC**
+      operationId: sendRawTransaction
+      parameters:
+        - in: query
+          name: hexstring
+          required: true
+          schema:
+            type: string
+          description: The hex string of the raw transaction
+          example: >-
+            ?hexstring=0400008085202f8901ab719872dfea1b4f594049722a92efafa4695322d2c08654aafe98c654606636000000006b483045022100e5f02014419280a5c1ed1f94513e8e2bee83f6341863b304fe093dea897f4aa20220022a6e6004dbf1305197f4053bd9dd59e21abd23a31d0188d079eb72cab84e990121036b6a136ce869a0b400548a9126f06d96181ee974ff1c7f5a5e54e39b7f66be05ffffffff0140420f00000000001976a9142e5db3157a9783c6208019323f2c3a02610826a988ac00000000a60a09000000000000000000000000
+        - in: query
+          name: allowhighfees
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: |
+            Allow high fees.
+            - `hexstring`=`<Hex string of raw tx>`&`allowhighfees`=`true`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: The transaction hash in hex
+              example:
+                status: success
+                data: >-
+                  381bfe56a049208ff90356153f024395b7a74b5ec470d639dd7e6ffa4487b2fe
+  /zelcash/createmultisig:
+    post:
+      tags:
+        - ZelCash
+      summary: Create multi-sig address
+      description: >-
+        Creates a multi-signature address with n signature of n keys required.
+        **PUBLIC**
+      operationId: createMultiSigPost
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                'n':
+                  type: integer
+                  description: >-
+                    The number of required signatures out of the n keys or
+                    addresses. Followed by Zel addresses in array of strings.
+                keys:
+                  type: array
+                  description: >-
+                    Array of keys which are Zelcash addresses or hex-encoded
+                    public keys
+                  items:
+                    type: string
+                    description: ZelCash address or hex-encoded public key
+            example:
+              'n': 2
+              keys:
+                - t1XcXfRFSnSeYmf2mbsMHzHbV8Qo5Zhk817
+                - t1RAxsCaeeqB2XbZqvYU87uTMo9K2RtcA9z
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/createmultisig'
+              example:
+                status: success
+                data:
+                  address: t3Sia7BaQ6cYYxj31PJWfxhwZwZozNzk9N7
+                  redeemScript: >-
+                    52210353b1620689dc80w0d9b634616ec8566f80e22fec5edd1c8edf64a8a07babc41f2103450768e972919f7c82ca85d904daf1d3d5beabd25230aca4f363aecfa912457895cd
+    get:
+      tags:
+        - ZelCash
+      summary: Create multi-sig address
+      description: >-
+        Creates a multi-signature address with n signature of n keys required.
+        **PUBLIC**
+      operationId: createMultiSig
+      parameters:
+        - in: query
+          name: 'n'
+          required: true
+          schema:
+            type: integer
+          description: >-
+            The number of required signatures out of the n keys or addresses.
+            Followed by Zel addresses in array of strings.
+          example: >-
+            ?n=2&keys=["t1XcXfRFSnSeYmf2mbsMHzHbV8Qo5Zhk817","t1RAxsCaeeqB2XbZqvYU87uTMo9K2RtcA9z"]
+        - in: query
+          name: keys
+          required: true
+          description: >
+            A json array of keys which are Zelcash addresses or hex-encoded
+            public keys.
+
+
+            Example:
+
+            -
+            `n`=`2`&`keys`=`["t1XcXfRFSnSeYmf2mbsMHzHbV8Qo5Zhk817","t1RAxsCaeeqB2XbZqvYU87uTMo9K2RtcA9z"]`
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/createmultisig'
+              example:
+                status: success
+                data:
+                  address: t3Sia7BaQ6cYYxj31PJWfxhwZwZozNzk9N7
+                  redeemScript: >-
+                    52210353b1620689dc80w0d9b634616ec8566f80e22fec5edd1c8edf64a8a07babc41f2103450768e972919f7c82ca85d904daf1d3d5beabd25230aca4f363aecfa912457895cd
+  /zelcash/estimatefee:
+    get:
+      tags:
+        - ZelCash
+      summary: Estimate fee nblocks
+      description: >-
+        Estimates the approximate fee per kilobyte needed for a transaction to
+        begin confirmation within nblocks blocks. **PUBLIC**
+      operationId: estimateFee
+      parameters:
+        - in: query
+          name: nblocks
+          required: true
+          schema:
+            type: integer
+          description: Number of nblocks
+          example: '?nblocks=5'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: integer
+                    description: >-
+                      Estimated fee-per-kilobyte -1.0 is returned if not enough
+                      transactions and blocks have been observed to make an
+                      estimate.
+              example:
+                status: success
+                data: -1
+  /zelcash/estimatepriority:
+    get:
+      tags:
+        - ZelCash
+      summary: Estimate priority nblocks
+      description: >-
+        Estimates the approximate priority a zero-fee transaction needs to begin
+        confirmation within nblocks blocks. **PUBLIC**
+      operationId: estimatePriority
+      parameters:
+        - in: query
+          name: nblocks
+          required: true
+          schema:
+            type: integer
+          description: Number of nblocks
+          example: '?nblocks=5'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: integer
+                    description: >-
+                      Estimated fee-per-kilobyte -1.0 is returned if not enough
+                      transactions and blocks have been observed to make an
+                      estimate.
+              example:
+                status: success
+                data: 0
+  /zelcash/validateaddress:
+    get:
+      tags:
+        - ZelCash
+      summary: Info of the Zelcash address
+      description: Return information about the given Zelcash address. **PUBLIC**
+      operationId: validateAddress
+      parameters:
+        - in: query
+          name: hexstring
+          required: true
+          schema:
+            type: string
+          description: Zelcash address to validate
+          example: '?zelcashaddress=t1N6mLX2A64QsyuLbYkfPZSrkLF86hxuuFe'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      isvalid:
+                        type: boolean
+                        description: >-
+                          If the address is valid or not. If not, this is the
+                          only property returned.
+                      address:
+                        type: string
+                        description: The Zelcash address validated
+                      scriptPubKey:
+                        type: string
+                        description: The hex encoded scriptPubKey generated by the address
+                      ismine:
+                        type: boolean
+                        description: If the address is yours or not
+                      iswatchonly:
+                        type: boolean
+                        description: If address is watch only
+                      isscript:
+                        type: boolean
+                        description: If the key is a script
+                      pubkey:
+                        type: string
+                        description: The hex value of the raw public key
+                      iscompressed:
+                        type: boolean
+                        description: If the address is compressed
+                      account:
+                        type: string
+                        description: >-
+                          DEPRECATED. The account associated with the address,
+                          "" is the default account
+              example:
+                status: success
+                data:
+                  isvalid: true
+                  address: t1N6mLX2A64QsyuLbYkfPZSrkLF86hxuuFe
+                  scriptPubKey: 76a9142e5db3157a9783c6208019323f2c3a02610826a988ac
+                  ismine: true
+                  iswatchonly: false
+                  isscript: false
+                  pubkey: >-
+                    036b6a136ce869a0b400548a9126f06d96181ee974ff1c7f5a5e54e39b7f66be05
+                  iscompressed: true
+                  account: ''
+  /zelcash/verifymessage:
+    post:
+      tags:
+        - ZelCash
+      summary: Verify a message
+      description: Verify a signed message. **PUBLIC**
+      operationId: verifyMessagePost
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                zelcashaddress:
+                  type: string
+                  description: The Zelcash address to use for the signature
+                signature:
+                  type: string
+                  description: The signature provided by the signer in base 64 encoding
+                message:
+                  type: string
+                  description: The message that was signed
+            example:
+              zelcashadress: t1N6mLX2A64QsyuLbYkfPZSrkLF86hxuuFe
+              signature: >-
+                H5j8AoJ+8VaEEJGgw846hSPQoq42X9yiLwn/Nab1pASBFcw8rj5k8J9xpKr1VzepMEOF2ProYxVsQ9i7xalH4Sk=
+              message: helloworld
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: boolean
+                    description: If the signature is verified or not.
+              example:
+                status: success
+                data: true
+    get:
+      tags:
+        - ZelCash
+      summary: Verify a message
+      description: Verify a signed message. **PUBLIC**
+      operationId: verifyMessage
+      parameters:
+        - in: query
+          name: zelcashaddress
+          required: true
+          schema:
+            type: string
+          description: The Zelcash address to use for the signature
+          example: '?zelcashaddress=t1N6mLX2A64QsyuLbYkfPZSrkLF86hxuuFe'
+        - in: query
+          name: signature
+          required: true
+          schema:
+            type: string
+          description: The signature provided by the signer in base 64 encoding
+          example: >-
+            ?zelcashaddress=...&signature=H5j8AoJ+8VaEEJGgw846hSPQoq42X9yiLwn/Nab1pASBFcw8rj5k8J9xpKr1VzepMEOF2ProYxVsQ9i7xalH4Sk=
+        - in: query
+          name: message
+          required: true
+          schema:
+            type: string
+          description: The message that was signed
+          example: '?zelcashaddress=...&signature=...&message=helloworld'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: boolean
+                    description: If the signature is verified or not.
+              example:
+                status: success
+                data: true
+  /zelcash/gettransaction:
+    get:
+      tags:
+        - ZelCash
+      summary: Information about in-wallet transaction
+      description: Get detailed information about in-wallet transaction. **PUBLIC**
+      operationId: getTransaction
+      parameters:
+        - in: query
+          name: txid
+          required: true
+          schema:
+            type: string
+          description: The transaction id
+          example: >-
+            ?txid=36666054c698feaa5486c0d2225369a4afef922a724940594f1beadf729871ab
+        - in: query
+          name: includewatchonly
+          schema:
+            type: boolean
+            default: false
+            enum:
+              - true
+              - false
+          description: |
+            Whether to include watchonly addresses in balance calculation and
+            details.
+
+            Example:
+            - `txid`=`<transaction id>`&`includewatchonly`=`true`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      amount:
+                        type: number
+                        description: The transaction amount in ZEL
+                      confirmations:
+                        type: number
+                        description: The number of confirmations
+                      blockhash:
+                        type: string
+                        description: The block hash
+                      blockindex:
+                        type: number
+                        description: The block index
+                      blocktime:
+                        type: number
+                        description: The time in seconds since epoch (1 Jan 1970 GMT)
+                      expiryheight:
+                        type: number
+                        description: Last valid block height for mining transaction
+                      txid:
+                        type: number
+                        description: The transaction id
+                      walletconflicts:
+                        $ref: '#/components/schemas/walletconflicts'
+                      time:
+                        type: number
+                        description: >-
+                          The transaction time in seconds since epoch (1 Jan
+                          1970 GMT)
+                      timereceived:
+                        type: number
+                        description: >-
+                          The time received in seconds since epoch (1 Jan 1970
+                          GMT)
+                      vJoinSplit:
+                        $ref: '#/components/schemas/joinsplit'
+                      details:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            account:
+                              type: string
+                              description: >-
+                                DEPRECATED. The account name involved in the
+                                transaction, can be "" for the default account
+                            address:
+                              type: string
+                              description: The Zelcash address involved in the transaction
+                            category:
+                              type: string
+                              description: 'The category, either send or receive'
+                            amount:
+                              type: number
+                              description: The amount in ZEL
+                            vout:
+                              type: integer
+                              description: The vout value
+                            size:
+                              type: integer
+                              description: Size in bytes
+                      hex:
+                        type: string
+                        description: Raw data for transaction
+              example:
+                status: success
+                data:
+                  amount: 1
+                  confirmations: 703
+                  blockhash: >-
+                    0000007e647cbb9c30bafcae9b37349a64c93f33f0b76ffdcea99f48002e24ec
+                  blockindex: 1
+                  blocktime: 1588765867
+                  expiryheight: 593098
+                  txid: >-
+                    36666054c698feaa5486c0d2225369a4afef922a724940594f1beadf729871ab
+                  walletconflicts: []
+                  time: 1588764826
+                  timereceived: 1588764826
+                  vJoinSplit: []
+                  details:
+                    - account: ''
+                      address: t1N6mLX2A64QsyuLbYkfPZSrkLF86hxuuFe
+                      category: receive
+                      amount: 1
+                      vout: 0
+                      size: 244
+                  hex: >-
+                    0400008085202f8901fb81c640b6231d12a538a2cf59637d268ced324b300aaf99f0b00814f585e216000000006a4730440220353c7289e7d67585411016dd0472fb752c22160d9962f0551e58bb183a984bc8022005109fef7d31921a44b2fdf841b15869810497ff3e53df936d66a0650581f02b01210330bf3e5792efc2f011d9cb322f984617bb4a63d8ca751771febe5fc585ac9fcdffffffff0200e1f505000000001976a9142e5db3157a9783c6208019323f2c3a02610826a988ac399e42c7070000001976a914548c1a1bc9e10e79a5b6d27a44393240f41c175188ac00000000ca0c09000000000000000000000000
+  /zelcash/zvalidateaddress:
+    get:
+      tags:
+        - ZelCash
+      summary: Information about given z address
+      description: Return information about the given z address. **PUBLIC**
+      operationId: zValidateAddress
+      parameters:
+        - in: query
+          name: zaddr
+          required: true
+          schema:
+            type: string
+          description: The z address to validate
+          example: >-
+            ?zaddr=za102nkanf5xu6asasvydwp3zlcuure23jqxxz0zqh9catfvc9cu0dfcvl35tz3qkf2q2cxc47g4mk
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      isvalid:
+                        type: boolean
+                        description: >-
+                          If the address is valid or not. If not, this is the
+                          only property returned.
+                      address:
+                        type: string
+                        description: The z address validated
+                      type:
+                        type: string
+                        description: Sprout or Sapling
+                      diversifier:
+                        type: string
+                        description: 'The hex value of the diversifier, d'
+                      diversifiedtransmissionkey:
+                        type: string
+                        description: The hex value of pk_d
+                      ismine:
+                        type: boolean
+                        description: If the address is yours or not
+              example:
+                status: success
+                data:
+                  isvalid: true
+                  address: >-
+                    za102nkanf5xu6asasvydwp3zlcuure23jqxxz0zqh9catfvc9cu0dfcvl35tz3qkf2q2cxc47g4mk
+                  type: sapling
+                  diversifier: 7aa76ecd343735d8760c23
+                  diversifiedtransmissionkey: >-
+                    6cb0022a5910c5a2f1339cdae3b8609656c7e502f1843140469507e7f88b185c
+                  ismine: true
+  /zelcash/getbenchmarks:
+    get:
+      tags:
+        - ZelCash
+      summary: Benchmark results
+      description: Return most recent benchmark results. **PUBLIC**
+      operationId: getBenchmarks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/getbenchmarks'
+              example:
+                status: success
+                data:
+                  ipaddress: 49.12.8.215
+                  status: BASIC
+                  time: 1588852143
+                  cores: 2
+                  ram: 3.799999952316284
+                  ssd: 0
+                  hdd: 51.23081207275391
+                  dd_write: 706.22802734375
+                  eps: 163.5512084960938
+  /zelcash/getbenchstatus:
+    get:
+      tags:
+        - ZelCash
+      summary: Bench status
+      description: >-
+        This will return the status of the node, what zelbenchd determined the
+        tier the server could pass for, and if ZelFlux backend is connected. If
+        any one of these return a negative result the ZelNode will fail to
+        confirm. **PUBLIC**
+      operationId: getBenchStatus
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/benchstatus'
+              example:
+                status: success
+                data:
+                  status: online
+                  benchmarking: BASIC
+                  zelback: connected
+  /zelcash/prioritisetransaction:
+    get:
+      tags:
+        - ZelCash
+      summary: Priortise a transaction
+      description: >-
+        Accepts the transaction into mined blocks at a higher (or lower)
+        priority. **USER**
+      operationId: prioritiseTransaction
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: txid
+          required: true
+          schema:
+            type: string
+          description: The transaction id
+          example: >-
+            ?txid=22ab3d049154c7d4b0f04b381770c655564facdc896a4f7e97aa5662f57a58c6
+        - in: query
+          name: prioritydelta
+          required: true
+          schema:
+            type: number
+          description: >-
+            The priority to add or subtract. The transaction selection algorithm
+            considers the tx as it would have a higher priority. (priority of a
+            transaction is calculated: coinage * value_in_satoshis / txsize)
+          example: '?txid=...&prioritydelta=0'
+        - in: query
+          name: feedelta
+          required: true
+          schema:
+            type: number
+          description: >-
+            The fee value (in satoshis) to add (or subtract, if negative). The
+            fee is not actually paid, only the algorithm for selecting
+            transactions into a block considers the transaction as it would have
+            paid a higher (or lower) fee.
+          example: '?txid=...&prioritydelta=...&feedelta=10000'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: boolean
+                    description: Returns true
+              example:
+                status: success
+                data: true
+  /zelcash/reindexzelcash:
+    get:
+      tags:
+        - ZelCash
+      summary: Reindex ZelCash daemon
+      description: >-
+        Tries to reindex ZelCash daemon running on the ZelNode the call is run
+        against. ZelCash daemon is firstly stopped and then started with reindex
+        flag. **ADMIN**
+      operationId: reindexZelCash
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: ZelCash successfully reindexing
+  /zelcash/stop:
+    get:
+      tags:
+        - ZelCash
+      summary: Stop ZelCash daemon
+      description: This will stop the ZelCash daemon from running. **ADMIN**
+      operationId: stop
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Stop Zelcash server
+  /zelcash/createzelnodekey:
+    get:
+      tags:
+        - ZelCash
+      summary: Create zelnode private key
+      description: Create a new zelnode private key. **ADMIN**
+      operationId: createZelNodeKey
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Zelnode private key
+              example:
+                status: success
+                data: 5JwVKe7UH986ncSL2jG9KdUY2AuZUTDAkTsp4TZoGWdD5cLLiFR
+  /zelcash/listzelnodeconf:
+    get:
+      tags:
+        - ZelCash
+      summary: The zelnode conf file
+      description: >-
+        View zelnode conf file in JSON format, this will return empty for most
+        unless running a hot wallet. **ADMIN**
+      operationId: listZelNodeConf
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        alias:
+                          type: string
+                          description: Alias name
+                        status:
+                          type: string
+                          description: Status of zelnode
+                        collateral:
+                          type: string
+                          description: Collateral txid and output index
+                        txhash:
+                          type: string
+                          description: Transaction id
+                        outputIndex:
+                          type: integer
+                          description: Output index
+                        privateKey:
+                          type: string
+                          description: Zelnode private key
+                        address:
+                          type: string
+                          description: Ip address of zelnode server and port
+                        ip:
+                          type: string
+                          description: Ip address of zelnode server
+                        network:
+                          type: string
+                          description: 'Network type (IPv4, IPv6, onion)'
+                        added_height:
+                          type: integer
+                          description: Block height zelnode was added to list
+                        confirmed_height:
+                          type: integer
+                          description: Block height zelnode was confirmed by the network
+                        last_confirmed_height:
+                          type: integer
+                          description: Latest block height network confirmed the zelnode
+                        last_paid_height:
+                          type: integer
+                          description: Block the zelnode was last paid
+                        tier:
+                          type: string
+                          description: Tier of zelnode
+                        payment_address:
+                          type: string
+                          description: Address where rewards are paid
+                        activesince:
+                          type: integer
+                          description: Last paid time in epoch
+                        lastpaid:
+                          type: integer
+                          description: Last paid time in epoch
+              example:
+                status: success
+                data:
+                  - alias: zn1
+                    status: OFFLINE
+                    collateral: >-
+                      COutPoint(2bcd3c84c84f87eaa86e4e56834c92927a07f9e18718810b92e0d0324456a67c,
+                      0)
+                    txhash: >-
+                      2bcd3c84c84f87eaa86e4e56834c92927a07f9e18718810b92e0d0324456a67c
+                    outputIndex: 0
+                    privateKey: 93HaYBVUCYjEMeeH1Y4sBGLALQZE1Yc1K64xiqgX37tGBDQL8Xg
+                    address: '127.0.0.2:16125'
+                    ip: UNKNOWN
+                    network: UNKNOWN
+                    added_height: 0
+                    confirmed_height: 0
+                    last_confirmed_height: 0
+                    last_paid_height: 0
+                    tier: UNKNOWN
+                    payment_address: UNKNOWN
+                    activesince: 0
+                    lastpaid: 0
+  /zelcash/getzelnodeoutputs:
+    get:
+      tags:
+        - ZelCash
+      summary: Zelnode transaction outputs
+      description: Print all zelnode transaction outputs. **ADMIN**
+      operationId: getZelNodeOutputs
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        txhash:
+                          type: string
+                          description: Output transaction hash
+                        outputidx:
+                          type: number
+                          description: Output index number
+              example:
+                status: success
+                data:
+                  - txhash: >-
+                      cee4c36d22609004d286bd83bebf1f28feb33dd6e4889c6c400766253942c1af
+                    outputidx: 0
+  /zelcash/startzelnode:
+    get:
+      tags:
+        - ZelCash
+      summary: Start ZelNode commmand
+      description: >-
+        Attempts to start one or more ZelNode. This call will only work if
+        running a hot ZelNode which is highly not recommended. It is a control
+        wallet function so basically your wallet containing the collateral
+        funds. **ADMIN**
+      operationId: startZelNode
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: set
+          required: true
+          schema:
+            type: number
+          description: Specify which set of ZelNode(s) to start.
+          example: '?set=alias'
+        - in: query
+          name: lockwallet
+          required: true
+          schema:
+            type: boolean
+            enum:
+              - true
+              - false
+          description: |
+            Lock wallet after completion.
+
+            Example:
+            - `set`=`<alias>`&`lockwallet`=`false`
+        - in: path
+          name: alias
+          required: true
+          schema:
+            type: string
+          description: Zelnode alias. Required if using 'alias' as the set.
+          example: '?set=alias&lockwallet=...&alias=Super1'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/startzelnode'
+              example:
+                status: success
+                data:
+                  overall: 'Successfully started 0 zelnodes, failed to start 1, total'
+                  detail:
+                    - result: failed
+                      error: could not find alias in config. Verify with list-conf.
+  /zelcash/startdeterministiczelnode:
+    get:
+      tags:
+        - ZelCash
+      summary: Start zelnode command
+      description: >-
+        Attempts to start one zelnode. Same as the `/zelcash/startzelnode` call
+        this call will only work if running a hot ZelNode which is highly not
+        recommended. It is a control wallet function so basically your wallet
+        containing the collateral funds.  **ADMIN**
+      operationId: startDeterministicZelNode
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: alias
+          required: true
+          schema:
+            type: string
+          description: Node name or alias.
+          example: '?alias=Basic1'
+        - in: query
+          name: lockwallet
+          required: true
+          schema:
+            type: boolean
+            enum:
+              - true
+              - false
+          description: |
+            Lock wallet after completion.
+
+            Example:
+            - `alias`=`<alias`&`lockwallet`=`false`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/startzelnode'
+              example:
+                status: success
+                data:
+                  overall: 'Successfully started 0 zelnodes, failed to start 1, total'
+                  detail:
+                    - alias: Basic1
+                      result: failed
+                      error: could not find alias in config. Verify with list-conf.
+  /zelcash/verifychain:
+    get:
+      tags:
+        - ZelCash
+      summary: Verify blockchain data
+      description: Verifies blockchain database. **ADMIN**
+      operationId: verifyChain
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: checklevel
+          schema:
+            type: integer
+            default: 3
+            enum:
+              - 0
+              - 1
+              - 2
+              - 3
+              - 4
+          description: |
+            How thorough the block verification is.
+
+            Example:
+            - `checklevel`=`1`
+        - in: query
+          name: numblocks
+          schema:
+            type: integer
+            default: 288
+          description: The number of blocks to check
+          example: '?numblocks=200'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: boolean
+                    description: Verified or not
+              example:
+                status: success
+                data: true
+  /zelcash/addnode:
+    get:
+      tags:
+        - ZelCash
+      summary: 'Add, remove, or try to connect a node'
+      description: >-
+        Attempts to add or remove a node from the addnode list. Or try a
+        connection to a node once. **ADMIN**
+      operationId: addNode
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: node
+          required: true
+          schema:
+            type: string
+          description: 'The node''s ip:port (see `/zelcash/getpeerinfo` for nodes)'
+          example: '?node=188.239.61.210:16125'
+        - in: query
+          name: command
+          required: true
+          schema:
+            type: string
+            enum:
+              - add
+              - remove
+              - onetry
+          description: |
+            Use 'add' to add a node to the list, 'remove' to remove a node from
+            the list, 'onetry' to try a connection to the node once.
+
+            Example:
+            - `node`=`<ip:port>`&`command`=`add`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/clearbanned:
+    get:
+      tags:
+        - ZelCash
+      summary: Clear banned IP's
+      description: Clear all banned IP's. **ADMIN**
+      operationId: clearBanned
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/disconnectnode:
+    get:
+      tags:
+        - ZelCash
+      summary: Disconnect a node
+      description: Immediately disconnects from the specified node. **ADMIN**
+      operationId: disconnectNode
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: node
+          required: true
+          schema:
+            type: string
+          description: 'The node''s ip:port'
+          example: '?node=188.239.61.210:16125'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/getaddednodeinfo:
+    get:
+      tags:
+        - ZelCash
+      summary: Info of added node/nodes
+      description: >-
+        Returns information about the given added node, or all added nodes(note
+        that onetry addnodes are not listed here). If dns is false, only a list
+        of added nodes will be provided, otherwise connected information will
+        also be available. **ADMIN**
+      operationId: getAddedNodeInfo
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: dns
+          required: true
+          schema:
+            type: boolean
+            enum:
+              - true
+              - false
+          description: >-
+            If false, only a list of added nodes will be provided, otherwise
+            connected information will also be available.
+        - in: query
+          name: node
+          schema:
+            type: string
+          description: 'The node ip:port'
+          example: '?dns=...&node=188.239.61.210:16125'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        addednode:
+                          type: string
+                          description: The node ip address
+                        connected:
+                          type: boolean
+                          description: If connected
+                        addresses:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              address:
+                                type: string
+                                description: The Zelcash server host and port
+                              connected:
+                                type: string
+                                description: 'Connection, inbound or outbound'
+              example:
+                status: success
+                data:
+                  - addednode: explorer.zel.cash
+                    connected: true
+                    addresses:
+                      - address: '159.65.254.184:16125'
+                        connected: outbound
+                  - addednode: explorer2.zel.cash
+                    connected: true
+                    addresses:
+                      - address: '80.211.207.17:16125'
+                        connected: outbound
+                  - addednode: explorer.zel.zelcore.io
+                    connected: true
+                    addresses:
+                      - address: '206.189.0.55:16125'
+                        connected: outbound
+  /zelcash/setban:
+    get:
+      tags:
+        - ZelCash
+      summary: Add or remove a IP from banned list
+      description: Attempts add or remove a IP/Subnet from the banned list. **ADMIN**
+      operationId: setBan
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: ip
+          required: true
+          schema:
+            type: string
+          description: >-
+            The IP/Subnet (see getpeerinfo for nodes ip) with a optional netmask
+            (default is /32 = single ip)
+          example: '?ip=188.239.61.210'
+        - in: query
+          name: command
+          required: true
+          schema:
+            type: string
+            enum:
+              - add
+              - remove
+          description: >-
+            Use 'add' to add a IP/Subnet to the list, 'remove' to remove a
+            IP/Subnet from the list
+          example: '?ip=...&command=add'
+        - in: query
+          name: bantime
+          schema:
+            type: integer
+            default: 86400
+          description: >-
+            Time in seconds how long (or until when if absolute is set) the ip
+            is banned (0 or empty means using the default time of 24h which can
+            also be overwritten by the -bantime startup argument)
+          example: '?ip=...&command=...&bantime=3500'
+        - in: query
+          name: absolute
+          schema:
+            type: boolean
+            enum:
+              - false
+              - true
+          description: >
+            If set, the bantime must be a absolute timestamp in seconds since
+
+            epoch (Jan 1 1970 GMT)
+
+
+            Example:
+
+            - `ip`=`<ip
+            address>`&`command`=`<add/remove>`&`bantime`=`1590368400`&`absolute`=`true`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/signrawtransaction:
+    post:
+      tags:
+        - ZelCash
+      summary: Sign raw transaction
+      description: >-
+        Sign inputs for raw transaction (serialized, hex-encoded). The second
+        optional argument (may be null) is an array of previous transaction
+        outputs that this transaction depends on but may not yet be in the block
+        chain. The third optional argument (may be null) is an array of
+        base58-encoded private keys that, if given, will be the only keys used
+        to sign the transaction. **ADMIN**
+      operationId: signRawTransactionPost
+      security:
+        - ZelID: []
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                hexstring:
+                  type: string
+                  description: Hex string of raw transaction
+                prevtxs:
+                  description: >-
+                    An json array of previous dependent transaction outputs
+                    (json array of json objects, or null if none provided).
+                    (optional)
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      txid:
+                        type: string
+                        description: The transaction id
+                      vout:
+                        type: integer
+                        description: Output index
+                      scriptPubKey:
+                        type: string
+                        description: Script key
+                      redeemScript:
+                        type: string
+                        description: Redeem script
+                      amount:
+                        type: number
+                        description: The amount spent
+                privatekeys:
+                  description: >-
+                    A json array of base58-encoded private keys for signing
+                    (optional)
+                  type: array
+                  items:
+                    type: string
+                    description: Private key in base58-encoding
+                sighashtype:
+                  type: string
+                  default: ALL
+                  enum:
+                    - ALL
+                    - NONE
+                    - SINGLE
+                    - ALL|ANYONECANPAY
+                    - NONE|ANYONECANPAY
+                    - SINGLE|ANYONECANPAY
+                  description: >-
+                    The signature hash type. Must be one of the available values
+                    listed. (optional)
+                branchid:
+                  type: string
+                  description: >-
+                    The hex representation of the consensus branch id to sign
+                    with. This can be used to force signing with consensus rules
+                    that are ahead of the node's current height. (optional)
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/signrawtransaction'
+              example:
+                status: success
+                data:
+                  hex: >-
+                    0400008085202f8901ab719872dfea1b4f594049722a92efafa4695322d2c08654aafe98c654606636000000006b483045022100e5f02014419280a5c1ed1f94513e8e2bee83f6341863b304fe093dea897f4aa20220022a6e6004dbf1305197f4053bd9dd59e21abd23a31d0188d079eb72cab84e990121036b6a136ce869a0b400548a9126f06d96181ee974ff1c7f5a5e54e39b7f66be05ffffffff0140420f00000000001976a9142e5db3157a9783c6208019323f2c3a02610826a988ac00000000a60a09000000000000000000000000
+                  complete: true
+    get:
+      tags:
+        - ZelCash
+      summary: Sign raw transaction
+      description: >-
+        Sign inputs for raw transaction (serialized, hex-encoded). The second
+        optional argument (may be null) is an array of previous transaction
+        outputs that this transaction depends on but may not yet be in the block
+        chain. The third optional argument (may be null) is an array of
+        base58-encoded private keys that, if given, will be the only keys used
+        to sign the transaction. **ADMIN**
+      operationId: signRawTransaction
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: hexstring
+          required: true
+          schema:
+            type: string
+          description: Hex string of raw transaction
+          example: >-
+            ?hexstring=0400008085202f8901ab719872dfea1b4f594049722a92efafa4695322d2c08654aafe98c6546066360000000000ffffffff0140420f00000000001976a9142e5db3157a9783c6208019323f2c3a02610826a988ac00000000a60a09000000000000000000000000
+        - in: query
+          name: prevtxs
+          description: >
+            An json array of previous dependent transaction outputs (json array
+            of json objects, or null if none provided).
+
+
+            List of objects key/value pairs in order:
+
+            - `txid`:`<transaction id>`
+
+            - `vout`:`<output index>`
+
+            - `scriptPubKey`:`<script key>`
+
+            - `redeemScript`:`<redeem script>`
+
+            - `amount`:`<the amount spent>`
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                txid:
+                  type: string
+                  description: The transaction id
+                vout:
+                  type: integer
+                  description: The output number
+                scriptPubKey:
+                  type: string
+                  description: Script key
+                redeemScript:
+                  type: string
+                  description: Redeem script
+                amount:
+                  type: number
+                  description: The amount spent
+        - in: query
+          name: privatekeys
+          description: >-
+            A json array of base58-encoded private keys for signing (json array
+            of strings, or null if none provided).
+          schema:
+            type: array
+            items:
+              type: string
+              description: Private key in base58-encoding
+        - in: query
+          name: sighashtype
+          schema:
+            type: string
+            default: ALL
+            enum:
+              - ALL
+              - NONE
+              - SINGLE
+              - ALL|ANYONECANPAY
+              - NONE|ANYONECANPAY
+              - SINGLE|ANYONECANPAY
+          description: The signature hash type. Must be one of the available values listed.
+        - in: query
+          name: branchid
+          schema:
+            type: string
+          description: >-
+            The hex representation of the consensus branch id to sign with. This
+            can be used to force signing with consensus rules that are ahead of
+            the node's current height.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/signrawtransaction'
+              example:
+                status: success
+                data:
+                  hex: >-
+                    0400008085202f8901ab719872dfea1b4f594049722a92efafa4695322d2c08654aafe98c654606636000000006b483045022100e5f02014419280a5c1ed1f94513e8e2bee83f6341863b304fe093dea897f4aa20220022a6e6004dbf1305197f4053bd9dd59e21abd23a31d0188d079eb72cab84e990121036b6a136ce869a0b400548a9126f06d96181ee974ff1c7f5a5e54e39b7f66be05ffffffff0140420f00000000001976a9142e5db3157a9783c6208019323f2c3a02610826a988ac00000000a60a09000000000000000000000000
+                  complete: true
+  /zelcash/addmultisigaddress:
+    post:
+      tags:
+        - ZelCash
+      summary: Add multisig address to the wallet
+      description: >-
+        Add a nrequired-to-sign multisignature address to the wallet. Each key
+        is a Zelcash address or hex-encoded public key. **ADMIN**
+      operationId: addMultiSigAddressPost
+      security:
+        - ZelID: []
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                'n':
+                  type: string
+                  description: >-
+                    The number of required signatures out of the n keys or
+                    addresses
+                keysobject:
+                  description: >-
+                    A json array of Zelcash addresses or hex-encoded public
+                    keys.
+                  type: array
+                  items:
+                    type: string
+                    description: Zelcash address or hex-encoded public key
+            example:
+              'n': 2
+              keysobject:
+                - t1b4SUue7q26dADLGUyFBu57uJsKS7jc8VC
+                - t1TtEnZKBziV5LziBXr9KvrYC2HbQA91rSN
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Multi-sig address.
+              example:
+                status: success
+                data: t3Sia7BaQ6cYYxj31PJWfxhwZwZozNzk9N7
+    get:
+      tags:
+        - ZelCash
+      summary: Add multisig address to the wallet
+      description: >-
+        Add a nrequired-to-sign multisignature address to the wallet. Each key
+        is a Zelcash address or hex-encoded public key. **ADMIN**
+      operationId: addmultisigaddress
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: 'n'
+          required: true
+          schema:
+            type: integer
+          description: The number of required signatures out of the n keys or addresses
+          example: '?n=2'
+        - in: query
+          name: keysobject
+          required: true
+          description: |
+            A json array of Zelcash addresses or hex-encoded public keys.
+
+            Example:
+            - `n`=`2`&`keysobject`=`[<"address">, <"address">]`
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Multi-sig address.
+              example:
+                status: success
+                data: t3Sia7BaQ6cYYxj31PJWfxhwZwZozNzk9N7
+  /zelcash/backupwallet:
+    get:
+      tags:
+        - ZelCash
+      summary: Backup wallet to destination file
+      description: Safely copies wallet.dat to destination filename. **ADMIN**
+      operationId: backupWallet
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: destination
+          required: true
+          schema:
+            type: string
+          description: >-
+            The destination filename, saved in the directory set by -exportdir
+            option
+          example: '?destination=walletbackup'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: The full path of the destination file
+              example:
+                status: success
+                data: /home/zel/backup/walletbackup
+  /zelcash/dumpprivkey:
+    get:
+      tags:
+        - ZelCash
+      summary: Get private key of a t-addr
+      description: Reveals the private key corresponding to t-addr. **ADMIN**
+      operationId: dumpPrivKey
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: taddr
+          required: true
+          schema:
+            type: string
+          description: The transparent address for the private key
+          example: '?taddr=t1LGoWfLf66bpJC84zWmUd9i1bkW9kFgnyQ'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: The private key
+              example:
+                status: success
+                data: KyqvmC4mDgxwnKjfGYPVt1wonwog4kZ8oA8WsL5yr7vE2X5phxwx
+  /zelcash/getbalance:
+    get:
+      tags:
+        - ZelCash
+      summary: Total balance of wallet
+      description: Returns the server's total available balance. **ADMIN**
+      operationId: getBalance
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: minconf
+          schema:
+            type: integer
+            default: 1
+          description: Only include transactions confirmed at least this many times
+          example: '?minconf=5'
+        - in: query
+          name: includewatchonly
+          schema:
+            type: boolean
+            default: false
+            enum:
+              - true
+              - false
+          description: |
+            Also include balance in watchonly addresses.
+
+            Example:
+            - `includewatchonly`=`true`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: number
+                    description: Zel balance
+              example:
+                status: success
+                data: 0
+  /zelcash/getnewaddress:
+    get:
+      tags:
+        - ZelCash
+      summary: Get new address
+      description: Returns a new Zelcash address for receiving payments. **ADMIN**
+      operationId: getNewAddress
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Zel address
+              example:
+                status: success
+                data: t1LGoWfLf66bpJC84zWmUVcw1bkW9kFgnyQ
+  /zelcash/getrawchangeaddress:
+    get:
+      tags:
+        - ZelCash
+      summary: Get new change address
+      description: >-
+        Returns a new Zelcash address, for receiving change. This is for use
+        with raw transactions, NOT normal use. **ADMIN**
+      operationId: getRawChangeAddress
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Zel address
+              example:
+                status: success
+                data: t1dC6WNjqcJX8VFcdRp1MyJ7eB4MSQs83FR
+  /zelcash/getreceivedbyaddress:
+    get:
+      tags:
+        - ZelCash
+      summary: Total received by the address
+      description: >-
+        Returns the total amount received by the given Zelcash address in
+        transactions with at least minconf confirmations. **ADMIN**
+      operationId: getReceivedByAddress
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: zelcashaddress
+          required: true
+          schema:
+            type: string
+          description: The Zelcash address for transactions
+          example: '?zelcashaddress=t1dC6WNjqcJX8VFcdRp1MyJ7eB4MSQs83FR'
+        - in: query
+          name: minconf
+          schema:
+            type: integer
+            default: 1
+          description: Only include transactions confirmed at least this many times
+          example: '?zelcashaddress=...&minconf=5'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: number
+                    description: The total amount in ZEL received at this address
+              example:
+                status: success
+                data: 0
+  /zelcash/getunconfirmedbalance:
+    get:
+      tags:
+        - ZelCash
+      summary: Get total unconfirmed balance
+      description: Returns the server's total unconfirmed balance. **ADMIN**
+      operationId: getUnconfirmedBalance
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: number
+                    description: Unconfirmed balance
+              example:
+                status: success
+                data: 0
+  /zelcash/getwalletinfo:
+    get:
+      tags:
+        - ZelCash
+      summary: Get various info of the wallet
+      description: Returns an object containing various wallet state info. **ADMIN**
+      operationId: getWalletInfo
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      walletversion:
+                        type: integer
+                        description: The wallet version
+                      balance:
+                        type: number
+                        description: The total confirmed balance of the wallet in ZEL
+                      unconfirmed_balance:
+                        type: number
+                        description: The wallet version
+                      immature_balance:
+                        type: number
+                        description: The total unconfirmed balance of the wallet in ZEL
+                      txcount:
+                        type: integer
+                        description: The total number of transactions in the wallet
+                      keypoololdest:
+                        type: integer
+                        description: >-
+                          The timestamp (seconds since GMT epoch) of the oldest
+                          pre-generated key in the key pool
+                      keypoolsize:
+                        type: integer
+                        description: How many new keys are pre-generated
+                      paytxfee:
+                        type: number
+                        description: 'The transaction fee configuration, set in ZEL/kB'
+                      seedfp:
+                        type: string
+                        description: The BLAKE2b-256 hash of the HD seed
+              example:
+                status: success
+                data:
+                  walletversion: 60000
+                  balance: 0
+                  unconfirmed_balance: 0
+                  immature_balance: 0
+                  txcount: 0
+                  keypoololdest: 1589023670
+                  keypoolsize: 101
+                  paytxfee: 0
+                  seedfp: >-
+                    2b800c3e5439562748d8d875e116c3f88364112eb18647529b147d2f69a80ce5
+  /zelcash/importaddress:
+    get:
+      tags:
+        - ZelCash
+      summary: Import address to watch
+      description: >-
+        Adds an address or script (in hex) that can be watched as if it were in
+        your wallet but cannot be used to spend. **ADMIN**
+      operationId: importAddress
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema:
+            type: string
+          description: The Zelcash address
+          example: '?address=t1dC6WNjqcJX8VFcdRp1MyJ7eB4MSQs83FR'
+        - in: query
+          name: label
+          schema:
+            type: string
+            default: '""'
+          description: Optional label
+          example: '?zelcashaddress=...&label=watchonly'
+        - in: query
+          name: rescan
+          schema:
+            type: boolean
+            default: true
+            enum:
+              - true
+              - false
+          description: >-
+            Rescan the wallet for transactions (This call can take some time to
+            complete if rescan is true)
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/importprivkey:
+    get:
+      tags:
+        - ZelCash
+      summary: Import private key to the wallet
+      description: >-
+        Adds a private key (as returned by dumpprivkey) to your wallet.
+        **ADMIN**
+      operationId: importPrivKey
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: zelcashprivkey
+          required: true
+          schema:
+            type: string
+          description: The private key
+          example: '?zelcashprivkey=KyqvmC4mDgxwnKjfGYPVt1wonwog4kZ8oA8WsL5yr7vE2X5phxwx'
+        - in: query
+          name: label
+          schema:
+            type: string
+            default: '""'
+          description: Optional label
+          example: '?zelcashprivkey=...&label=import1'
+        - in: query
+          name: rescan
+          schema:
+            type: boolean
+            default: true
+            enum:
+              - true
+              - false
+          description: >-
+            Rescan the wallet for transactions (This call can take some time to
+            complete if rescan is true)
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/importwallet:
+    get:
+      tags:
+        - ZelCash
+      summary: Import private keys from the dump file
+      description: Imports taddr keys from a wallet dump file. **ADMIN**
+      operationId: importWallet
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: filename
+          required: true
+          schema:
+            type: string
+          description: The name of backup
+          example: '?filename=dumpwallet'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/keypoolrefill:
+    get:
+      tags:
+        - ZelCash
+      summary: Refill keypool
+      description: >-
+        Fills the keypool with more keys. Rarely used as not many will come
+        close to using more than it comes with by default. **ADMIN**
+      operationId: keyPoolRefill
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: newsize
+          required: true
+          schema:
+            type: integer
+          description: The new keypool size
+          example: '?newsize=150'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/listaddressgroupings:
+    get:
+      tags:
+        - ZelCash
+      summary: A list of addresses that have been used and known to the public
+      description: >-
+        Lists groups of addresses which have had their common ownership made
+        public by common use as inputs or as the resulting change in past
+        transactions. **ADMIN**
+      operationId: listAddressGroupings
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: string
+                      description: 'Zel address, balance, and label'
+              example:
+                status: success
+                data:
+                  - - - t1LGoWfLf66bpJC84zWmUVcw1bkW9kFgnyQ
+                      - 0.1
+                      - ''
+                  - - - t1T83Nj5ai9n32SMYZMFtqBAnNU3opMisGg
+                      - 53.16539081
+                      - ''
+  /zelcash/listlockunspent:
+    get:
+      tags:
+        - ZelCash
+      summary: List of unspendable outputs
+      description: Returns list of temporarily unspendable outputs. **ADMIN**
+      operationId: listLockUnspent
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        txid:
+                          type: string
+                          description: The transaction id
+                        vout:
+                          type: integer
+                          description: Vout value
+              example:
+                status: success
+                data:
+                  - txid: >-
+                      15430c14500cd505798902e2f1ce3c19251f3599954e7dfb57c19f8763530860
+                    vout: 0
+  /zelcash/listreceivedbyaddress:
+    get:
+      tags:
+        - ZelCash
+      summary: List of balances
+      description: List balances by receiving address. **ADMIN**
+      operationId: listReceivedByAddress
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: minconf
+          schema:
+            type: integer
+            default: 1
+          description: The minimum number of confirmations before payments are included
+          example: '?minconf=5'
+        - in: query
+          name: includeempty
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: Whether to include addresses that haven't received any payments
+          example: '?includeempty=true'
+        - in: query
+          name: includewatchonly
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: Whether to include watchonly addresses
+          example: '?includewatchonly=true'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        involvesWatchonly:
+                          type: boolean
+                          description: >-
+                            Only returned if imported addresses were involved in
+                            transaction
+                        address:
+                          type: string
+                          description: The receiving address
+                        account:
+                          type: string
+                          description: >-
+                            The account of the receiving address. The default
+                            account is ""
+                        amount:
+                          type: number
+                          description: The total amount in ZEL received by the address
+                        confirmations:
+                          type: integer
+                          description: >-
+                            The number of confirmations of the most recent
+                            transaction included
+                        txids:
+                          type: array
+                          items:
+                            type: string
+                            description: Tranaction ids
+              example:
+                status: success
+                data:
+                  - address: t1LGoWfLf66bpJC84zWmUVcw1bkW9kFgnyQ
+                    account: ''
+                    amount: 0.01
+                    confirmations: 384
+                    txids:
+                      - >-
+                        15430c14500cd505798902e2f1ce3c19251f3599954e7dfb57c19f8763530860
+                  - involvesWatchonly: true
+                    address: t1T83Nj5ai9n32SMYZMFtqBAnNU3opMisGg
+                    account: watchonly
+                    amount: 53.16539081
+                    confirmations: 78
+                    txids:
+                      - >-
+                        4f92889223b93cdcfed3499beee96eabc4ee84fb8051df1d80cd2bb0f780870a
+                      - >-
+                        5ac98d5bf3c24c3c5eead54592a44c39152dc31cd4ffa98323842f22d5a62619
+                      - >-
+                        c1dcd9ce345a85783417f9015b3371001739425b67ef5a6c459be85782b0e86e
+                      - >-
+                        fd1e3c162a3d858bd6f53ba59d4fca0854c0843fdab692c7af6da1113ca30fb2
+                      - >-
+                        0f249e4bd193182526dab806fe552dba5d16a864a32803455b2d6c769f19ecb2
+  /zelcash/listsinceblock:
+    get:
+      tags:
+        - ZelCash
+      summary: List of transactions since block (blockhash)
+      description: >-
+        Get all transactions in blocks since block [blockhash], or all
+        transactions if omitted. **ADMIN**
+      operationId: listSinceBlock
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: blockhash
+          schema:
+            type: string
+          description: The block hash to list transactions since
+          example: >-
+            ?blockhash=000000b43fccbefdc72246275014e641d400851ab88f1b3f8ec483a770072537
+        - in: query
+          name: targetconfirmations
+          schema:
+            type: integer
+          description: 'The confirmations required, must be 1 or more'
+          example: '?targetconfirmations=50'
+        - in: query
+          name: includewatchonly
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: Whether to include watchonly addresses
+          example: '?includewatchonly=true'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      transactions:
+                        $ref: '#/components/schemas/listtransactions'
+                      lastblock:
+                        type: string
+                        description: The hash of the last block
+              example:
+                status: success
+                data:
+                  transactions:
+                    - account: ''
+                      address: t1LGoWfLf66bpJC84zWmUVcw1bkW9kFgnyQ
+                      category: receive
+                      amount: 0.1
+                      vout: 0
+                      confirmations: 342
+                      blockhash: >-
+                        000000e6d86f170fbd09f550a1abe0f8a70a1ba43d4d08f676f5dc7b5eca0645
+                      blockindex: 2
+                      blocktime: 1589158561
+                      expiryheight: 596355
+                      txid: >-
+                        15430c14500cd505798902e2f1ce3c19251f3599954e7dfb57c19f8763530860
+                      walletconflicts: []
+                      time: 1589158522
+                      timereceived: 1589158522
+                      vJoinSplit: []
+                      size: 245
+                  lastblock: >-
+                    000000b288eaf9eb45e0beb1d1e271530741e41a235068e95856bcdd57ed3e2c
+  /zelcash/listtransactions:
+    get:
+      tags:
+        - ZelCash
+      summary: List of recent transactions
+      description: >-
+        Returns up to count most recent transactions skipping the first from
+        transactions for account 'account'. **ADMIN**
+      operationId: listTransactions
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: count
+          schema:
+            default: 10
+            type: integer
+          description: The number of transactions to return
+          example: '?count=25'
+        - in: query
+          name: from
+          schema:
+            default: 0
+            type: integer
+          description: The number of transactions to skip
+          example: '?from=5'
+        - in: query
+          name: includewatchonly
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: Whether to include watchonly addresses
+          example: '?includewatchonly=true'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/listtransactions'
+              example:
+                status: success
+                data:
+                  account: ''
+                  address: t1LGoWfLf66bpJC84zWmUVcw1bkW9kFgnyQ
+                  amount: 0.1
+                  vout: 0
+                  confirmations: 343
+                  blockhash: >-
+                    000000e6d86f170fbd09f550a1abe0f8a70a1ba43d4d08f676f5dc7b5eca0645
+                  blockindex: 2
+                  blocktime: 1589158561
+                  expiryheight: 596355
+                  txid: >-
+                    15430c14500cd505798902e2f1ce3c19251f3599954e7dfb57c19f8763530860
+                  walletconflicts: []
+                  time: 1589158522
+                  timereceived: 1589158522
+                  vJoinSplit: []
+                  size: 245
+  /zelcash/listunspent:
+    get:
+      tags:
+        - ZelCash
+      summary: Returns objects of unspent transactions
+      description: >-
+        Returns array of unspent transaction outputs with between minconf and
+        maxconf (inclusive) confirmations. Optionally filter to only include
+        txouts paid to specified addresses. Results are an array of Objects,
+        each of which has: (txid, vout, scriptPubKey, amount, confirmations).
+        **ADMIN**
+      operationId: listUnspent
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: minconf
+          schema:
+            default: 1
+            type: integer
+          description: The minimum confirmations to filter
+          example: '?minconf=5'
+        - in: query
+          name: maxconf
+          schema:
+            default: 9999999
+            type: integer
+          description: The maximum confirmations to filter
+          example: '?maxconf=100000'
+        - in: query
+          name: addresses
+          schema:
+            type: array
+            items:
+              type: string
+          description: |
+            A json array of Zelcash addresses to filter.
+
+            Examples:
+            - `addresses`=`["taadr", "taddr"]`
+            - `addresses`=`<taadr>`&`addresses`=`<addr>`
+
+            If filtering a single address url encode the array or try
+            - `address`=`["taadr"]`
+          style: form
+          explode: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        txid:
+                          type: string
+                          description: Tranaction id
+                        vout:
+                          type: integer
+                          description: Vout value
+                        generated:
+                          type: boolean
+                          description: True if txout is a coinbase transaction output
+                        address:
+                          type: string
+                          description: The Zel address
+                        account:
+                          type: string
+                          description: >-
+                            The associated account, or "" for the default
+                            account
+                        scriptPubKey:
+                          type: string
+                          description: The script key
+                        amount:
+                          type: number
+                          description: The transaction amount in ZEL
+                        confirmations:
+                          type: integer
+                          description: The number of confirmations
+                        spendable:
+                          type: boolean
+                          description: >-
+                            Whether we have the private keys to spend this
+                            output
+              example:
+                status: success
+                data:
+                  txid: >-
+                    4f92889223b93cdcfed3499beee96eabc4ee84fb8051df1d80cd2bb0f780870a
+                  vout: 2
+                  generated: false
+                  address: t1T83Nj5ai9n32SMYZMFtqBAnNU3opMisGg
+                  account: ''
+                  scriptPubKey: 76a914657421e07d891e5eed4ffa8a2845a5f6ef0ac17088ac
+                  amount: 10.53093108
+                  confirmations: 342
+                  spendable: true
+  /zelcash/lockunspent:
+    get:
+      tags:
+        - ZelCash
+      summary: Updates list of temporarily unspendable outputs
+      description: >-
+        Temporarily lock (unlock=false) or unlock (unlock=true) specified
+        transaction outputs. A locked transaction output will not be chosen by
+        automatic coin selection, when spending Zelcash. Locks are stored in
+        memory only. Nodes start with zero locked outputs, and the locked output
+        list is always cleared (by virtue of process exit) when a node stops or
+        fails. **ADMIN**
+      operationId: lockUnspent
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: unlock
+          required: true
+          schema:
+            type: boolean
+            enum:
+              - true
+              - false
+          description: Whether to unlock (true) or lock (false) the specified transactions
+          example: '?unlock=false'
+        - in: query
+          name: transactions
+          required: true
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                txid:
+                  type: string
+                  description: transaction id
+                vout:
+                  type: integer
+                  description: vout value
+          description: >
+            Each transaction the txid and vout key/value pair is both required. 
+
+            - `txid`:`<transaction id>`
+
+            - `vout`:`<output index>`
+
+
+            Url encoded example:
+
+            -
+            `unlock`=`<true/false>`&`transactions`=`%5B%7B%22txid%22%3A%2215430c14500cd505798902e2f1ce3c19251f3599954e7dfb57c19f8763530860%22%2C%22vout%22%3A0%7D%5D`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: boolean
+                    description: Whether the command was successful or not
+              example:
+                status: success
+                data: true
+  /zelcash/rescanblockchain:
+    get:
+      tags:
+        - ZelCash
+      summary: Rescans blockchain for transactions
+      description: >-
+        Rescans the blockchain looking for transactions that belong to this
+        wallet. **ADMIN**
+      operationId: rescanBlockchain
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: startheight
+          schema:
+            default: 0
+            type: integer
+          description: Block height to start rescan from
+          example: '?startheight=545000'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Rescan Completed
+  /zelcash/sendmany:
+    post:
+      tags:
+        - ZelCash
+      summary: Send multiple transactions at once
+      description: >-
+        Send multiple times. Amounts are decimal numbers with at most 8 digits
+        of precision. **ADMIN**
+      operationId: sendManyPost
+      security:
+        - ZelID: []
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                amounts:
+                  type: object
+                  description: >-
+                    A json object with addresses and amounts. The zelcash
+                    address is the key, the numeric amount in ZEL is the value.
+                minconf:
+                  type: integer
+                  default: 1
+                  description: >-
+                    Only use the balance confirmed at least this many times
+                    (optional)
+                comment:
+                  type: string
+                  description: >-
+                    A comment used to store what the transaction is for. This is
+                    not part of the transaction, just kept in your wallet.
+                    (optional)
+                substractfeefromamount:
+                  type: boolean
+                  description: >-
+                    Subtract the transaction fee equally from the output amounts
+                    (optional)
+            example:
+              amounts:
+                t1b4SUue7q26dADLGUyFBu57uJsKS7jc8VC: 0.0001
+                t1TtEnZKBziV5LziBXr9KvrYC2HbQA91rSN: 0.0001
+              minconf: 2
+              comment: test api
+              substractfeefromamount: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Transaction id
+              example:
+                status: success
+                data: >-
+                  fe196c167d679737c716f06b66ca7249be0476b7a086c7736a38f050eab62169
+    get:
+      tags:
+        - ZelCash
+      summary: Send multiple transactions at once
+      description: >-
+        Send multiple times. Amounts are decimal numbers with at most 8 digits
+        of precision. **ADMIN**
+      operationId: sendMany
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: amounts
+          required: true
+          description: >-
+            A json object with addresses and amounts. The zelcash address is the
+            key, the numeric amount in ZEL is the value.
+          schema:
+            type: object
+            properties:
+              amounts:
+                type: string
+          example:
+            t1QSE45jkZ9docBDFh4yEV91fgZgESp5hZN: 0.001
+            t1Nmbgvqg9zqmuW8VTXrfWzL2aTnuWARX91: 0.001
+            t1LoTuyuH9smQ2NrYDFfn4kLfiuhKnAEELv: 0.001
+        - in: query
+          name: minconf
+          schema:
+            default: 1
+            type: number
+          description: Only use the balance confirmed at least this many times
+          example: '?amounts=...&minconf=3'
+        - in: query
+          name: comment
+          schema:
+            type: string
+          description: >-
+            A comment used to store what the transaction is for. This is not
+            part of the transaction, just kept in your wallet.
+          example: '?amounts=...&comment=Pay Zel Foundation'
+        - in: query
+          name: substractfeefromamount
+          description: Subtract the transaction fee equally from the output amounts.
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Transaction id
+              example:
+                status: success
+                data: >-
+                  a7a6d8c1c4e155cf94af58ea1e4a8e3ddd7cc4cb1bc4d86242c1118bdf9469f2
+  /zelcash/sendtoaddress:
+    post:
+      tags:
+        - ZelCash
+      summary: Send Zel to an address
+      description: Send an amount to a given address. **ADMIN**
+      operationId: sendToAddressPost
+      security:
+        - ZelID: []
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                zelcashaddress:
+                  type: string
+                  description: The zelcash address to send to
+                amount:
+                  type: number
+                  description: The amount in ZEL to send
+                comment:
+                  type: string
+                  description: >-
+                    A comment used to store what the transaction is for. This is
+                    not part of the transaction, just kept in your wallet.
+                    (optional)
+                commentto:
+                  type: string
+                  description: >-
+                    comment to store the name of the person or organization to
+                    which you're sending the transaction. This is not part of
+                    the transaction, just kept in your wallet. (optional)
+                substractfeefromamount:
+                  type: boolean
+                  default: false
+                  description: >-
+                    Subtract the transaction fee equally from the output
+                    amounts. (optional)
+            example:
+              zelcashaddress: t1QSE45jkZ9docBDFh4yEV91fgZgESp5hZN
+              amount: 0.001
+              comment: Test api
+              commentto: self
+              substractfeefromamount: false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Transaction id
+              example:
+                status: success
+                data: >-
+                  bbb0f5de68db9c661e11ec38c6e0cc99a1e1d202b64dc69d5a58d665dc4b5b19
+    get:
+      tags:
+        - ZelCash
+      summary: Send Zel to an address
+      description: Send an amount to a given address. **ADMIN**
+      operationId: sendToAddress
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: zelcashaddress
+          required: true
+          schema:
+            type: string
+            description: The zelcash address to send to
+          example: '?zelcashaddress=t1QSE45jkZ9docBDFh4yEV91fgZgESp5hZN'
+        - in: query
+          name: amount
+          required: true
+          schema:
+            type: number
+          description: The amount in ZEL to send
+          example: '?zelcashaddress=...&amount=0.001'
+        - in: query
+          name: comment
+          schema:
+            type: string
+          description: >-
+            A comment used to store what the transaction is for. This is not
+            part of the transaction, just kept in your wallet.
+          example: '?zelcashaddress=...&amount=...&comment=Test api'
+        - in: query
+          name: commentto
+          schema:
+            type: string
+          description: >-
+            A comment to store the name of the person or organization to which
+            you're sending the transaction. This is not part of the transaction,
+            just kept in your wallet.
+          example: '?zelcashaddress=...&amount=...&commentto=Self'
+        - in: query
+          name: substractfeefromamount
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: >-
+            The fee will be deducted from the amount being sent if set to true
+            and the recipient will receive less Zelcash than you enter in the
+            amount field.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Transaction id
+              example:
+                status: success
+                data: >-
+                  bbb0f5de68db9c661e11ec38c6e0cc99a1e1d202b64dc69d5a58d665dc4b5b19
+  /zelcash/settxfee:
+    get:
+      tags:
+        - ZelCash
+      summary: Set transaction fee
+      description: This will restart the zelcash daemon. **ADMIN**
+      operationId: setTxFee
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: amount
+          required: true
+          schema:
+            type: number
+          description: The transaction fee in ZEL/kB rounded to the nearest 0.00000001
+          example: '?amount=0.00001'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: boolean
+                    description: Returns true if successful
+              example:
+                status: success
+                data: true
+  /zelcash/signmessage:
+    post:
+      tags:
+        - ZelCash
+      summary: Sign a message
+      description: Sign a message with the private key of a t-addr. **ADMIN**
+      operationId: signMessagePost
+      security:
+        - ZelID: []
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                taddr:
+                  type: string
+                  description: The transparent address to use for the private key
+                message:
+                  type: string
+                  description: The message to create a signature of
+            example:
+              taddr: t1N6mLX2A64QsyuLbYkfPZSrkLF86hxuuFe
+              message: helloworld
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: The signature of the message encoded in base 64.
+              example:
+                status: success
+                data: >-
+                  H5j8AoJ+8VaEEJGgw846hSPQoq42X9yiLwn/Nab1pASBFcw8rj5k8J9xpKr1VzepMEOF2ProYxVsQ9i7xalH4Sk=
+    get:
+      tags:
+        - ZelCash
+      summary: Sign a message
+      description: Sign a message with the private key of a t-addr. **ADMIN**
+      operationId: signMessage
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: taddr
+          required: true
+          schema:
+            type: string
+          description: The transparent address to use for the private key
+          example: '?taddr=t1N6mLX2A64QsyuLbYkfPZSrkLF86hxuuFe'
+        - in: query
+          name: message
+          required: true
+          schema:
+            type: string
+          description: The message to create a signature of
+          example: '?taddr=...&message=helloworld'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: The signature of the message encoded in base 64.
+              example:
+                status: success
+                data: >-
+                  H5j8AoJ+8VaEEJGgw846hSPQoq42X9yiLwn/Nab1pASBFcw8rj5k8J9xpKr1VzepMEOF2ProYxVsQ9i7xalH4Sk=
+  /zelcash/zexportkey:
+    get:
+      tags:
+        - ZelCash
+      summary: Reveal z-addr private key
+      description: Reveals the zkey corresponding to zaddr. **ADMIN**
+      operationId: zExportKey
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: zaddr
+          required: true
+          schema:
+            type: string
+          description: The zaddr for the private key
+          example: >-
+            ?zaddr=za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: The private key
+              example:
+                status: success
+                data: >-
+                  secret-extended-key-main1qdg0nnspqqqqpqxh3quajk7fux5njuukqs3caqrhcx6cvm0f47ftlktlkm76a0pxfara7jntype360dacdzftzm8vjpqn6ytsduud40r63t3nnal0n8qp687hcje7rmp334v8zlua38f7r8emrtl2x5zjmeh97rky0j6tugr0m6qt8dxmduyawfcgjyt3v5x84753ywffwnjtsf58kfnjhdfrx3k9wgnjm7vgv7d20826s5lapfaljhpeufvsl98zf50het6a3wyj7c0xm9p7
+  /zelcash/zexportviewingkey:
+    get:
+      tags:
+        - ZelCash
+      summary: Reveal z-addr viewing key
+      description: >-
+        Reveals the viewing key corresponding to zaddr. Only works with sprout
+        zaddr's. **ADMIN**
+      operationId: zExportViewingKey
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: zaddr
+          required: true
+          schema:
+            type: string
+          description: The zaddr for the private key
+          example: >-
+            ?zaddr=zcQNG88SQVQTuqGKdeDDhVRCXkHeR3Vv5BqeBBaYziyN48FpJM2buK1YmQtpKoVkwrM2vvhCdrVofkdLc8QYeSLyiAkQB1u
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: The viewing key
+              example:
+                status: success
+                data: >-
+                  ZiVKeT3VBMzNRzA6hzaYzd3d7ebcsaR9iRkhYC8nRwrVYnMZGwPCz62UJMHZnjbPURAaKqDhazDWHies6HMcHmazQUUd4R3TH
+  /zelcash/zgetbalance:
+    get:
+      tags:
+        - ZelCash
+      summary: Returns the balance of a taddr or zaddr
+      description: >-
+        Returns the balance of a taddr or zaddr belonging to the node's wallet.
+        CAUTION If the wallet has only an incoming viewing key for this address,
+        then spends cannot be detected, and so the returned balance may be
+        larger than the actual balance. **ADMIN**
+      operationId: zGetBalance
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema:
+            type: string
+          description: Zel address
+          example: >-
+            ?address=zcQNG88SQVQTuqGKdeDDhVRCXkHeR3Vv5BqeBBaYziyN48FpJM2buK1YmQtpKoVkwrM2vvhCdrVofkdLc8QYeSLyiAkQB1u
+        - in: query
+          name: minconf
+          schema:
+            default: 1
+            type: integer
+          description: Only include transactions confirmed at least this many times
+          example: '?address=...&minconf=5'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: The viewing key
+              example:
+                status: success
+                data: 0
+  /zelcash/zgetmigrationstatus:
+    get:
+      tags:
+        - ZelCash
+      summary: Returns status info of the sprout to sapling migration
+      description: >-
+        Returns information about the status of the Sprout to Sapling migration.
+        Note that a transaction is defined as finalized if it has at least ten
+        confirmations. Also, it is possible that manually created transactions
+        involving this wallet will be included in the result. **ADMIN**
+      operationId: zGetMigrationStatus
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                        description: Whether or not migration is enabled
+                      unmigrated_amount:
+                        type: number
+                        description: The total amount of unmigrated ZEL
+                      unfinalized_migrated_amount:
+                        type: number
+                        description: The total amount of unfinalized ZEL
+                      finalized_migrated_amount:
+                        type: number
+                        description: The total amount of finalized ZEL
+                      finalized_migration_transactions:
+                        type: integer
+                        description: >-
+                          The number of migration transactions involving this
+                          wallet
+                      migration_txids:
+                        type: array
+                        items:
+                          type: string
+                          description: >-
+                            An array of all migration txids involving this
+                            wallet
+              example:
+                status: success
+                data:
+                  enabled: false
+                  unmigrated_amount: 0
+                  unfinalized_migrated_amount: 0
+                  finalized_migrated_amount: 0
+                  finalized_migration_transactions: 0
+                  migration_txids: []
+  /zelcash/zgetnewaddress:
+    get:
+      tags:
+        - ZelCash
+      summary: Create new shielded address
+      description: Returns a new shielded address for receiving payments. **ADMIN**
+      operationId: zGetNewAddress
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: type
+          schema:
+            default: sapling
+            type: string
+            enum:
+              - sapling
+              - sprout
+          description: |
+            The type of z-address.
+
+            Example:
+            - `type`=`sapling`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: The new shielded address
+              example:
+                status: success
+                data: >-
+                  za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd
+  /zelcash/zgetoperationresult:
+    get:
+      tags:
+        - ZelCash
+      summary: Get operation result
+      description: >-
+        Retrieve the result and status of an operation which has finished, and
+        then remove the operation from memory. **ADMIN**
+      operationId: zGetOperationResult
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: operationid
+          description: >
+            List of operation ids. If not provided, examine all operations known
+            to the node.
+
+
+            Example:
+
+            - `operationid`=`["opid-6869eaa7-722f-4991-9a6e-fd6b4c388755"]`
+          schema:
+            type: array
+            items:
+              type: string
+              description: operation id
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/zoperationstatus'
+              example:
+                status: success
+                data:
+                  - id: opid-6869eaa7-722f-4991-9a6e-fd6b4c388755
+                    status: success
+                    creation_time: 1589372035
+                    result:
+                      txid: >-
+                        ed1e5e81e51505fbdfa9be60ebced208f1e3a5922b0f03ad050f6459fbd54501
+                    execution_secs: 0.995255071
+                    method: z_sendmany
+                    params:
+                      fromaddress: t1YvykLWgwT5yjVjt3GH9YEyaTdMgPsainF
+                      amounts:
+                        - address: >-
+                            za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd
+                          amount: 0.001
+                    minconf: 1
+                    fee: 0.0001
+  /zelcash/zgetoperationstatus:
+    get:
+      tags:
+        - ZelCash
+      summary: Get operation status
+      description: >-
+        Get operation status and any associated result or error data.  The
+        operation will remain in memory. **ADMIN**
+      operationId: zGetOperationStatus
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: operationid
+          description: >
+            List of operation ids. If not provided, examine all operations known
+            to the node.
+
+
+            Example:
+
+            - `operationid`=`["opid-bdf41571-3a20-4a00-bbf2-d4e9ddbb3375"]`
+          schema:
+            type: array
+            items:
+              type: string
+              description: operation id
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/zoperationstatus'
+              example:
+                status: success
+                data:
+                  - id: opid-bdf41571-3a20-4a00-bbf2-d4e9ddbb3375
+                    status: success
+                    creation_time: 1589371435
+                    result:
+                      txid: >-
+                        5a115247fe1944daf91d0a66ee383beadecf4d591809eaecff33c93a00f13566
+                    execution_secs: 54.108955058
+                    method: z_sendmany
+                    params:
+                      fromaddress: t1SHbSQdw9JkHZVyw7zkL8MiAxeAcWgxQtx
+                      amounts:
+                        - address: >-
+                            zcQNG88SQVQTuqGKdeDDhVRCXkHeR3Vv5BqeBBaYziyN48FpJM2buK1YmQtpKoVkwrM2vvhCdrVofkdLc8QYeSLyiAkQB1u
+                          amount: 0.001
+                    minconf: 1
+                    fee: 0.0001
+  /zelcash/zgettotalbalance:
+    get:
+      tags:
+        - ZelCash
+      summary: Get total balance of wallet
+      description: Return the total value of funds stored in the node's wallet. **ADMIN**
+      operationId: zGetTotalBalance
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: minconf
+          schema:
+            default: 1
+            type: integer
+          description: >-
+            Only include private and transparent transactions confirmed at least
+            this many times
+          example: '?minconf=5'
+        - in: query
+          name: includewatchonly
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: Also include balance in watchonly addresses
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      transparent:
+                        type: number
+                        description: The total balance of transparent funds
+                      private:
+                        type: number
+                        description: The total balance of shielded funds
+                      total:
+                        type: number
+                        description: >-
+                          The total balance of both transparent and shielded
+                          funds
+              example:
+                status: success
+                data:
+                  transparent: 0.09999476
+                  private: 0
+                  total: 0.09999476
+  /zelcash/zimportkey:
+    get:
+      tags:
+        - ZelCash
+      summary: Import zaddress private key
+      description: Adds a zkey to your wallet. **ADMIN**
+      operationId: zImportKey
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: zkey
+          required: true
+          schema:
+            type: string
+          description: The zkey
+          example: >-
+            ?zkey=secret-extended-key-main1qdg0nnspqqqqpqxh3quajk7fux5njuukqs3caqrhcx6cvm0f47ftlktlkm76a0pxfara7jntype360dacdzftzm8vjpqn6ytsduud40r63t3nnal0n8qp687hcje7rmp334v8zlua38f7r8emrtl2x5zjmeh97rky0j6tugr0m6qt8dxmduyawfcgjyt3v5x84753ywffwnjtsf58kfnjhdfrx3k9wgnjm7vgv7d20826s5lapfaljhpeufvsl98zf50het6a3wyj7c0xm9p7
+        - in: query
+          name: rescan
+          schema:
+            default: whenkeyisnew
+            type: string
+            enum:
+              - whenkeyisnew
+              - 'yes'
+              - 'no'
+          description: |
+            Rescan the wallet for transactions.
+            Example:
+            - `zkey`=`<z private key>`&`rescan`=`yes`
+        - in: query
+          name: startheight
+          schema:
+            default: 0
+            type: integer
+          description: Block height to start rescan from
+          example: '?zkey=...&startheight=500000'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/zimportviewingkey:
+    get:
+      tags:
+        - ZelCash
+      summary: Import zaddress viewing key
+      description: Adds a viewing key to your wallet. **ADMIN**
+      operationId: zImportViewingKey
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: vkey
+          required: true
+          schema:
+            type: string
+          description: The viewing key
+          example: >-
+            ?vkey=ZiVKeT3VBMzNRzA6hzaYzd3d7ebcsaR9iRkhYC8nRwrVYnMZGwPCz62UJMHZnjbPURAaKqDhazDWHies6HMcHmazQUUd4R3TH
+        - in: query
+          name: rescan
+          schema:
+            default: whenkeyisnew
+            type: string
+            enum:
+              - whenkeyisnew
+              - 'yes'
+              - 'no'
+          description: Rescan the wallet for transactions. E.g. ?vkey=...&rescan=yes
+        - in: query
+          name: startheight
+          schema:
+            default: 0
+            type: integer
+          description: Block height to start rescan from
+          example: '?zkey=...&startheight=500000'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/zimportwallet:
+    get:
+      tags:
+        - ZelCash
+      summary: Import wallet from export file
+      description: Imports taddr and zaddr keys from a wallet export file. **ADMIN**
+      operationId: zImportWallet
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: filename
+          required: true
+          schema:
+            type: string
+          description: The wallet file
+          example: '?filename=/path/to/file'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/zlistaddresses:
+    get:
+      tags:
+        - ZelCash
+      summary: Get list of all shielded addresses
+      description: >-
+        Returns the list of Sprout and Sapling shielded addresses belonging to
+        the wallet. **ADMIN**
+      operationId: zListAddresses
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: includewatchonly
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: Also include watchonly addresses
+          example: '?includewatchonly=true'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: string
+                      description: Zaddr's belonging to wallet
+              example:
+                status: success
+                data:
+                  - >-
+                    zcQNG88SQVQTuqGKdeDDhVRCXkHeR3Vv5BqeBBaYziyN48FpJM2buK1YmQtpKoVkwrM2vvhCdrVofkdLc8QYeSLyiAkQB1u
+                  - >-
+                    za1j9fkv2p20t5pvzkxz5wnhxnwkf9mc7hmes9x4qfsy8z2zaq38fwpvny07lf4ynpul0gsq8d790v
+                  - >-
+                    za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd
+  /zelcash/zlistoperationids:
+    get:
+      tags:
+        - ZelCash
+      summary: Get list of operation ids
+      description: >-
+        Returns the list of operation ids currently known to the wallet.
+        **ADMIN**
+      operationId: zListOperationIds
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: string
+                      description: Operation id
+              example:
+                status: success
+                data:
+                  - opid-6869eaa7-722f-4991-9a6e-fd6b4c388755
+                  - opid-bdf41571-3a20-4a00-bbf2-d4e9ddbb3375
+  /zelcash/zlistreceivedbyaddress:
+    get:
+      tags:
+        - ZelCash
+      summary: List of amounts received by zaddr
+      description: >-
+        Return a list of amounts received by a zaddr belonging to the node's
+        wallet. **ADMIN**
+      operationId: zListReceivedByAddress
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema:
+            type: string
+          description: The shielded address
+          example: >-
+            ?address=za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd
+        - in: query
+          name: minconf
+          schema:
+            default: 1
+            type: integer
+          description: Only include transactions confirmed at least this many times
+          example: '?address=...&minconf=5'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        txid:
+                          type: string
+                          description: Transaction id
+                        jsindex:
+                          type: integer
+                          description: Joinsplit index (sprout txs)
+                        jsoutindex:
+                          type: integer
+                          description: Output index of the joinsplit (sprout txs)
+                        amount:
+                          type: number
+                          description: The amount of value in the note
+                        confirmations:
+                          type: integer
+                          description: Number of confirmations
+                        time:
+                          type: integer
+                          description: >-
+                            The transaction time in seconds since epoch (1 Jan
+                            1970 GMT)
+                        memo:
+                          type: string
+                          description: Hexadecimal string representation of memo field
+                        outindex:
+                          type: integer
+                          description: Output index number
+                        change:
+                          type: boolean
+                          description: >-
+                            True if the address that received the note is also
+                            one of the sending addresses
+              example:
+                status: success
+                data:
+                  - txid: >-
+                      ed1e5e81e51505fbdfa9be60ebced208f1e3a5922b0f03ad050f6459fbd54501
+                    amount: 0.001
+                    confirmations: 106
+                    time: 1589372036
+                    memo: >-
+                      f600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+                    outindex: 0
+                    change: false
+  /zelcash/zlistunspent:
+    get:
+      tags:
+        - ZelCash
+      summary: List of unspent shielded notes
+      description: >-
+        Returns array of unspent shielded notes with between minconf and maxconf
+        (inclusive) confirmations. **ADMIN**
+      operationId: zListUnspent
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: minconf
+          schema:
+            default: 1
+            type: string
+          description: The minimum confirmations to filter
+          example: '?minconf=5'
+        - in: query
+          name: maxconf
+          schema:
+            default: 9999999
+            type: integer
+          description: The maximum confirmations to filter
+          example: '?maxconf=100000'
+        - in: query
+          name: includewatchonly
+          schema:
+            default: false
+            type: boolean
+            enum:
+              - true
+              - false
+          description: Also include watchonly addresses
+          example: '?includewatchonly=true'
+        - in: query
+          name: addresses
+          description: >
+            Array of zaddrs (both Sprout and Sapling) to filter on.  Duplicate
+            addresses not allowed.
+
+
+            Example:
+
+            -
+            `addresses`=`["za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd","zcQNG88SQVQTuqGKdeDDhVRCXkHeR3Vv5BqeBBaYziyN48FpJM2buK1YmQtpKoVkwrM2vvhCdrVofkdLc8QYeSLyiAkQB1u"]`
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        txid:
+                          type: string
+                          description: Tranaction id
+                        jsindex:
+                          type: integer
+                          description: Joinsplit index (sprout txs)
+                        jsoutindex:
+                          type: integer
+                          description: Output index of the joinsplit (sprout txs)
+                        outindex:
+                          type: integer
+                          description: Output index (sapling)
+                        confirmations:
+                          type: integer
+                          description: Number of confirmations
+                        spendable:
+                          type: boolean
+                          description: >-
+                            True if note can be spent by wallet, false if
+                            address is watchonly
+                        address:
+                          type: string
+                          description: The shielded address
+                        amount:
+                          type: number
+                          description: Amount of value in the note
+                        memo:
+                          type: string
+                          description: Hexademical string representation of memo field
+                        change:
+                          type: boolean
+                          description: >-
+                            True if the address that received the note is also
+                            one of the sending addresses
+              example:
+                status: success
+                data:
+                  - txid: >-
+                      5a115247fe1944daf91d0a66ee383beadecf4d591809eaecff33c93a00f13566
+                    jsindex: 0
+                    jsoutindex: 0
+                    confirmations: 125
+                    spendable: true
+                    address: >-
+                      zcQNG88SQVQTuqGKdeDDhVRCXkHeR3Vv5BqeBBaYziyN48FpJM2buK1YmQtpKoVkwrM2vvhCdrVofkdLc8QYeSLyiAkQB1u
+                    amount: 0.001
+                    memo: >-
+                      f600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+                    change: false
+                  - txid: >-
+                      ed1e5e81e51505fbdfa9be60ebced208f1e3a5922b0f03ad050f6459fbd54501
+                    confirmations: 123
+                    spendable: true
+                    address: >-
+                      za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd
+                    amount: 0.001
+                    memo: >-
+                      f600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+                    change: false
+  /zelcash/zsendmany:
+    post:
+      tags:
+        - ZelCash
+      summary: Send multiple transactions
+      description: >-
+        Send multiple times. Amounts are decimal numbers with at most 8 digits
+        of precision. Change generated from a taddr flows to a new taddr
+        address, while change generated from a zaddr returns to itself. When
+        sending coinbase UTXOs to a zaddr, change is not allowed. The entire
+        value of the UTXO(s) must be consumed. Before Acadia (Sapling)
+        activates, the maximum number of zaddr outputs is 54 due to transaction
+        size limits. **ADMIN**
+      operationId: zSendManyPost
+      security:
+        - ZelID: []
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                fromaddress:
+                  type: string
+                  description: The taddr or zaddr to send the funds from
+                amounts:
+                  type: array
+                  description: An array of json objects representing the amounts to send
+                  items:
+                    type: object
+                    properties:
+                      address:
+                        type: string
+                        description: The taddr or zaddr to send the funds from
+                      amount:
+                        type: number
+                        description: The numeric amount in ZEL is the value
+                      memo:
+                        type: string
+                        description: >-
+                          If the address is a zaddr, raw data represented in
+                          hexadecimal string format. (optional)
+                minconf:
+                  type: integer
+                  default: 1
+                  description: Only use funds confirmed at least this many times (optional)
+                fee:
+                  type: number
+                  default: 0.0001
+                  description: The fee amount to attach to this transaction (optional)
+            example:
+              fromaddress: t1YvykLWgwT5yjVjt3GH9YEyaTdMgPsainF
+              amounts:
+                - address: >-
+                    za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd
+                  amount: 0.0001
+                  memo: 5465737420617069
+              minconf: 2
+              fee: 0.00001
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Operation id
+              example:
+                status: success
+                data: opid-e3f36550-d5cc-419d-b39c-5e822ed1e3b8
+    get:
+      tags:
+        - ZelCash
+      summary: Send multiple transactions
+      description: >-
+        Send multiple times. Amounts are decimal numbers with at most 8 digits
+        of precision. Change generated from a taddr flows to a new taddr
+        address, while change generated from a zaddr returns to itself. When
+        sending coinbase UTXOs to a zaddr, change is not allowed. The entire
+        value of the UTXO(s) must be consumed. Before Acadia (Sapling)
+        activates, the maximum number of zaddr outputs is 54 due to transaction
+        size limits. **ADMIN**
+      operationId: zSendMany
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: fromaddress
+          required: true
+          schema:
+            type: string
+          description: The taddr or zaddr to send the funds from
+          example: '?fromaddress=t1YvykLWgwT5yjVjt3GH9YEyaTdMgPsainF'
+        - in: query
+          name: amounts
+          description: >
+            An array of json objects representing the amounts to send.
+
+
+            Key/value pairs in order:
+
+            - `address`: `<receiving address>`
+
+            - `amount`: `<zel amount>`
+
+
+            Url encoded example:
+
+            -
+            `amounts`=`%5B%7B%22address%22%3A%22za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd%22%2C%22amount%22%3A0.001%7D%5D`
+          required: true
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                address:
+                  type: string
+                  description: The taddr or zaddr to send the funds from
+                amount:
+                  type: number
+                  description: The numeric amount in ZEL is the value
+                memo:
+                  type: string
+                  description: >-
+                    If the address is a zaddr, raw data represented in
+                    hexadecimal string format (optional)
+          example: >-
+            ?fromaddress=...&amounts=%5B%7B%22address%22%3A%22za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd%22%2C%22amount%22%3A0.001%7D%5D
+        - in: query
+          name: minconf
+          schema:
+            type: integer
+            default: 1
+          description: Only use funds confirmed at least this many times
+          example: '?fromaddress=...&amounts=...&minconf=5'
+        - in: query
+          name: fee
+          schema:
+            default: 0.0001
+            type: number
+          description: The fee amount to attach to this transaction
+          example: '?fromaddress=...&amounts=...&fee=0.000005'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Operation id
+              example:
+                status: success
+                data: opid-6869eaa7-722f-4991-9a6e-fd6b4c388755
+  /zelcash/zsetmigration:
+    get:
+      tags:
+        - ZelCash
+      summary: Migrate funds to a sapling adress
+      description: >-
+        When enabled the Sprout to Sapling migration will attempt to migrate all
+        funds from this wallet’s sprout addresses to either the address for
+        sapling account 0 or the address specified by the parameter
+        '-migrationdestaddress'. This migration is designed to minimize
+        information leakage. As a result for wallets with a significant sprout
+        balance, this process may take several weeks. The migration works by
+        sending, up to 5, as many transactions as possible whenever the
+        blockchain reaches a height equal to 499 modulo 500. The transaction
+        amounts are picked according to the random distribution specified in ZIP
+        308. The migration will end once the wallet’s sprout balance is below
+        0.01 ZEL. **ADMIN**
+      operationId: zSetMigration
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: enabled
+          required: true
+          schema:
+            type: boolean
+            enum:
+              - true
+              - false
+          description: True or false to enable or disable respectively
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/zshieldcoinbase:
+    get:
+      tags:
+        - ZelCash
+      summary: Shield coinbase
+      description: >-
+        Shield transparent coinbase funds by sending to a shielded zaddr. This
+        is an asynchronous operation and utxos selected for shielding will be
+        locked. If there is an error, they are unlocked.  The RPC call
+        listlockunspent can be used to return a list of locked utxos.  The
+        number of coinbase utxos selected for shielding can be limited by the
+        caller. If the limit parameter is set to zero, and Overwinter is not yet
+        active, the -mempooltxinputlimit option will determine the number of
+        uxtos. Any limit is constrained by the consensus rule defining a maximum
+        transaction size of 100000 bytes before Acadia (Sapling,) and 2000000
+        bytes once Acadia (Sapling) activates.. **ADMIN**
+      operationId: zShieldCoinBase
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: fromaddress
+          required: true
+          schema:
+            type: string
+          description: The address is a taddr or "*" for all taddrs belonging to the wallet
+          example: '?fromaddress="*"'
+        - in: query
+          name: toaddress
+          required: true
+          schema:
+            type: string
+          description: Zaddr to shield funds to
+          example: >-
+            ?fromaddress="*"&toaddress=za1kqwgkln5azfnnzfps0vc44ucwynstxk9k79z6nunwq0pnh4rjuww5kgy02c9wvfmdkxkxndlvdd
+        - in: query
+          name: fee
+          schema:
+            default: 0.0001
+            type: number
+          description: The fee amount to attach to this transaction
+        - in: query
+          name: limit
+          schema:
+            default: 50
+            type: integer
+          description: >-
+            Limit on the maximum number of utxos to shield.  Set to 0 to use
+            node option -mempooltxinputlimit (before Overwinter), or as many as
+            will fit in the transaction (after Overwinter).
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      remainingUTXOs:
+                        type: integer
+                        description: Number of coinbase utxos still available for shielding
+                      remainingValue:
+                        type: number
+                        description: Value of coinbase utxos still available for shielding
+                      shieldingUTXOs:
+                        type: integer
+                        description: Number of coinbase utxos being shielded
+                      shieldingValue:
+                        type: number
+                        description: Value of coinbase utxos being shielded
+                      opid:
+                        type: string
+                        description: >-
+                          An operationid to pass to z_getoperationstatus to get
+                          the result of the operation
+              example:
+                status: success
+                data:
+                  remainingUTXOs: 0
+                  remainingValue: 0
+                  shieldingUTXOs: 206
+                  shieldingValue: 3285
+                  opid: opid-55742ed9-021c-4fa7-9cd4-2d96843d1476
+  /zelcash/start:
+    get:
+      tags:
+        - ZelCash
+      summary: Start ZelCash daemon
+      description: >-
+        Tries to start ZelCash daemon running on the ZelNode the call is run
+        against without any extra parameters. **ADMIN** **ZELTEAM**
+      operationId: startZelCash
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: ZelCash successfully started
+  /zelcash/restart:
+    get:
+      tags:
+        - ZelCash
+      summary: Restart ZelCash daemon
+      description: >-
+        Tries to restart ZelCash daemon running on the ZelNode the call is run
+        against. ZelCash daemon is firstly stopped and then started without any
+        extra parameters. **ADMIN** **ZELTEAM**
+      operationId: restartZelCash
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/statusmessage'
+              example:
+                status: success
+                data:
+                  message: ZelCash successfully restarted
+  /zelcash/ping:
+    get:
+      tags:
+        - ZelCash
+      summary: Ping request to measure ping time
+      description: >-
+        Requests that a ping be sent to all other nodes, to measure ping time.
+        **ADMIN** **ZELTEAM**
+      operationId: ping
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/nullmessage'
+              example:
+                status: success
+                data: null
+  /zelcash/zcbenchmark:
+    get:
+      tags:
+        - ZelCash
+      summary: Run benchmark of selected type and samplecount times
+      description: >-
+        Runs a benchmark of the selected type and samplecount times, returning
+        the running times of each sample. **ADMIN** **ZELTEAM**
+      operationId: zcBenchmark
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: benchmarktype
+          required: true
+          schema:
+            type: string
+            enum:
+              - sleep
+              - createjoinsplit
+              - solveequihash
+              - loadwallet
+              - listunspent
+              - createsaplingspend
+              - createsaplingoutput
+              - verifysaplingspend
+              - verifysaplingoutput
+          description: Type of benchmark. Listed is just some of the benchmark types.
+          example: '?benchmarktype=sleep'
+        - in: query
+          name: samplecount
+          required: true
+          schema:
+            type: integer
+          description: Number of samples
+          example: '?benchmarktype=...&samplecount=2'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        runningtime:
+                          type: number
+                          description: Running time of the sample.
+              example:
+                status: success
+                data:
+                  - runningtime: 0.636
+                  - runningtime: 0.652
+  /zelcash/startzelbenchd:
+    get:
+      tags:
+        - ZelCash
+      summary: Start ZelBench daemon
+      description: Start ZelBench daemon. **ADMIN** **ZELTEAM**
+      operationId: startZelBenchD
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Starting process
+  /zelcash/stopzelbenchd:
+    get:
+      tags:
+        - ZelCash
+      summary: Stop ZelBench daemon
+      description: Stop ZelBench daemon. **ADMIN** **ZELTEAM**
+      operationId: stopZelBenchD
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Stopping process
+  /zelbench/getstatus:
+    get:
+      tags:
+        - ZelBench
+      summary: Zelbench status
+      description: >-
+        This will return the status of the node, what ZelBenchd determined the
+        tier the server could pass for, and if ZelFlux backend is connected. If
+        any one of these return a negative result the ZelNode will fail to
+        confirm. **PUBLIC**
+      operationId: getStatus
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/benchstatus'
+              example:
+                status: success
+                data:
+                  status: online
+                  benchmarking: SUPER
+                  zelback: connected
+  /zelbench/help:
+    get:
+      tags:
+        - ZelBench
+      summary: Zelbench calls
+      description: This will return with a list of calls for ZelBench. **PUBLIC**
+      operationId: zelBenchHelp
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: List of calls
+              example:
+                status: success
+                data: |-
+                  == Benchmarks ==
+                  getstatus (full_check)
+                  restartnodebenchmarks
+                  signzelnodetransaction "hexstring"
+
+                  == Control ==
+                  help ( "command" )
+                  stop
+
+                  == Zelnode ==
+                  getbenchmarks
+                  getinfo
+  /zelbench/getbenchmarks:
+    get:
+      tags:
+        - ZelBench
+      summary: Benchmark results
+      description: Return most recent benchmark results. **PUBLIC**
+      operationId: getBenchmarks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/getbenchmarks'
+              example:
+                status: success
+                data:
+                  ipaddress: 96.30.196.88
+                  status: SUPER
+                  time: 1588374276
+                  cores: 6
+                  ram: 15
+                  ssd: 0
+                  hdd: 400.0308227539062
+                  ddwrite: 290.239013671875
+                  eps: 259.3544006347656
+  /zelbench/getinfo:
+    get:
+      tags:
+        - ZelBench
+      summary: Zelbench status
+      description: This will return with the zelbench status of the zelnode. **PUBLIC**
+      operationId: zelBenchGetInfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/benchinfo'
+              example:
+                status: success
+                data:
+                  version: 1.3.1
+                  rpcport: 16224
+  /zelbench/restartnodebenchmarks:
+    get:
+      tags:
+        - ZelBench
+      summary: Restart ZelBench daemon
+      description: >-
+        This will restart the ZelBench daemon and start bench process.
+        **ZELTEAM** **ADMIN**
+      operationId: restartNodeBenchmarks
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Benchmarks will restart in the next couple minutes
+  /zelbench/stop:
+    get:
+      tags:
+        - ZelBench
+      summary: Stop zelbench daemon
+      description: This will stop the zelbench daemon. **ADMIN**
+      operationId: stop
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Zelbench server stopping
+  /zelbench/signzelnodetransaction:
+    post:
+      tags:
+        - ZelBench
+      summary: Sign ZelNode transaction
+      description: Command to get ZelBenchd to sign a ZelNode broadcast. **ADMIN**
+      operationId: signZelNodeTransactionPost
+      security:
+        - ZelID: []
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: object
+              properties:
+                hexstring:
+                  type: string
+                  description: The hex encoded ZelNode broadcast message
+            example:
+              hexstring: >-
+                0500000004566e906c6df24b00ca710cecbbea166a29b9098456bed212207fea66f433ba4500000000ba33bd5e01182ebd5e010f3131362e3230332e3233372e323530411b27b3e254a9f3248d88039a0f062e0d634e130bd34a9e4a1cb27d7aa6ce975cee251be9af6864a1a4a9e9d5fc2b28a07af8bab36a73f912c59ef844a69fa03f5f411c7f47ba609b2c0eb91268b446b31899ce66f90fa1375aab29692f1b252a53a9883120e10c646292486365608dc806c43e2d49b66afdd150a6a7f60b6b2392a83b
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/signzelnodetransaction'
+              example:
+                status: success
+                data:
+                  status: complete
+                  tier: BASIC
+                  hex: >-
+                    0500000004566e906c6df24b00ca710cecbbea166a29b9098456bed212207fea66f433ba4500000000ba33bd5e014d3cbd5e010f3131362e3230332e3233372e323530411b27b3e254a9f3248d88039a0f062e0d634e130bd34a9e4a1cb27d7aa6ce975cee251be9af6864a1a4a9e9d5fc2b28a07af8bab36a73f912c59ef844a69fa03f5f411b38e0e02dfece0ba3b7aae0afdcea7c70c9ea28b11317763f12092214086059e74d542cada464f3ee2c655011c53f6f18c0aa484bff8ce36926c6b295eb9287ff
+    get:
+      tags:
+        - ZelBench
+      summary: Sign ZelNode transaction
+      description: Command to get ZelBenchd to sign a ZelNode broadcast. **ADMIN**
+      operationId: signZelNodeTransaction
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: hexstring
+          required: true
+          schema:
+            type: string
+          description: The hex encoded zelnode broadcast message
+          example: >-
+            ?hexstring=0500000004566e906c6df24b00ca710cecbbea166a29b9098456bed212207fea66f433ba4500000000ba33bd5e01182ebd5e010f3131362e3230332e3233372e323530411b27b3e254a9f3248d88039a0f062e0d634e130bd34a9e4a1cb27d7aa6ce975cee251be9af6864a1a4a9e9d5fc2b28a07af8bab36a73f912c59ef844a69fa03f5f411c7f47ba609b2c0eb91268b446b31899ce66f90fa1375aab29692f1b252a53a9883120e10c646292486365608dc806c43e2d49b66afdd150a6a7f60b6b2392a83b
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/signzelnodetransaction'
+              example:
+                status: success
+                data:
+                  status: complete
+                  tier: BASIC
+                  hex: >-
+                    0500000004566e906c6df24b00ca710cecbbea166a29b9098456bed212207fea66f433ba4500000000ba33bd5e014d3cbd5e010f3131362e3230332e3233372e323530411b27b3e254a9f3248d88039a0f062e0d634e130bd34a9e4a1cb27d7aa6ce975cee251be9af6864a1a4a9e9d5fc2b28a07af8bab36a73f912c59ef844a69fa03f5f411b38e0e02dfece0ba3b7aae0afdcea7c70c9ea28b11317763f12092214086059e74d542cada464f3ee2c655011c53f6f18c0aa484bff8ce36926c6b295eb9287ff
+  /zelapps/listrunningzelapps:
+    get:
+      tags:
+        - ZelApps
+      summary: list running apps
+      description: List and info of running apps. **Public**
+      operationId: listRunningZelApps
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/containerinfo'
+              example:
+                status: success
+                data:
+                  - Id: >-
+                      9a1369a96d82e74173476d30b12ac70c7261c253433b1303737d0461c5cbedee
+                    Names:
+                      - /zelFoldingAtHome
+                    Image: 'yurinnick/folding-at-home:latest'
+                    ImageID: >-
+                      sha256:278b92c12d772dcfd77878fbb86714fd31d1c3e651b4f81761cc10b660cdb1d6
+                    Command: /opt/fahclient/entrypoint.sh --allow 0/0 --web-allow 0/0
+                    Created: 1587928808
+                    Ports:
+                      - PrivatePort: 36330
+                        Type: tcp
+                      - IP: 0.0.0.0
+                        PrivatePort: 7396
+                        PublicPort: 30000
+                        Type: tcp
+                    Labels:
+                      description: Unofficial Folding@Home image for CPU compute
+                      maintainer: yurinnick
+                      repository: 'https://github.com/yurinnick/folding-at-home-docker'
+                      version: 7.6
+                    State: running
+                    Status: Up 5 days
+                    HostConfig:
+                      NetworkMode: zelfluxDockerNetwork
+                    NetworkSettings:
+                      Networks:
+                        zelfluxDockerNetwork:
+                          IPAMConfig: null
+                          Links: null
+                          Aliases: null
+                          NetworkID: >-
+                            58358cee5a53dc4a089fb2f6341662cfb8aec702c5c16066ed3fd4c7570e330e
+                          EndpointID: >-
+                            f170fc599a65132a82fc6217cddc2ba40ade43263042dae0be8ab8ef4fadbec7
+                          Gateway: 172.16.0.1
+                          IPAddress: 172.16.0.2
+                          IPPrefixLen: 16
+                          IPv6Gateway: ''
+                          GlobalIPv6Address: ''
+                          GlobalIPv6PrefixLen: 0
+                          MacAddress: '02:42:ac:10:00:02'
+                          DriverOpts: null
+                    Mounts:
+                      - Type: bind
+                        Source: /home/zel/zelflux/ZelApps/zelFoldingAtHome
+                        Destination: /config
+                        Mode: ''
+                        RW: true
+                        Propagation: rprivate
+  /zelapps/listallzelapps:
+    get:
+      tags:
+        - ZelApps
+      summary: list all apps
+      description: List and info of all apps. **Public**
+      operationId: listAllZelApps
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/containerinfo'
+              example:
+                status: success
+                data:
+                  - Id: >-
+                      9a1369a96d82e74173476d30b12ac70c7261c253433b1303737d0461c5cbedee
+                    Names:
+                      - /zelFoldingAtHome
+                    Image: 'yurinnick/folding-at-home:latest'
+                    ImageID: >-
+                      sha256:278b92c12d772dcfd77878fbb86714fd31d1c3e651b4f81761cc10b660cdb1d6
+                    Command: /opt/fahclient/entrypoint.sh --allow 0/0 --web-allow 0/0
+                    Created: 1587928808
+                    Ports:
+                      - PrivatePort: 36330
+                        Type: tcp
+                      - IP: 0.0.0.0
+                        PrivatePort: 7396
+                        PublicPort: 30000
+                        Type: tcp
+                    Labels:
+                      description: Unofficial Folding@Home image for CPU compute
+                      maintainer: yurinnick
+                      repository: 'https://github.com/yurinnick/folding-at-home-docker'
+                      version: 7.6
+                    State: running
+                    Status: Up 5 days
+                    HostConfig:
+                      NetworkMode: zelfluxDockerNetwork
+                    NetworkSettings:
+                      Networks:
+                        zelfluxDockerNetwork:
+                          IPAMConfig: null
+                          Links: null
+                          Aliases: null
+                          NetworkID: >-
+                            58358cee5a53dc4a089fb2f6341662cfb8aec702c5c16066ed3fd4c7570e330e
+                          EndpointID: >-
+                            f170fc599a65132a82fc6217cddc2ba40ade43263042dae0be8ab8ef4fadbec7
+                          Gateway: 172.16.0.1
+                          IPAddress: 172.16.0.2
+                          IPPrefixLen: 16
+                          IPv6Gateway: ''
+                          GlobalIPv6Address: ''
+                          GlobalIPv6PrefixLen: 0
+                          MacAddress: '02:42:ac:10:00:02'
+                          DriverOpts: null
+                    Mounts:
+                      - Type: bind
+                        Source: /home/zel/zelflux/ZelApps/zelFoldingAtHome
+                        Destination: /config
+                        Mode: ''
+                        RW: true
+                        Propagation: rprivate
+  /zelapps/listzelappsimages:
+    get:
+      tags:
+        - ZelApps
+      summary: List of images
+      description: List of zelapps images installed. **Public**
+      operationId: listZelAppsImages
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        Containers:
+                          type: integer
+                          description: Container number
+                        Created:
+                          type: integer
+                          description: Time created in epoch time
+                        Id:
+                          type: string
+                          description: Hash of image
+                        Labels:
+                          type: object
+                          description: User-defined key/value metadata
+                          properties:
+                            description:
+                              type: string
+                              description: Description of image
+                            maintainer:
+                              type: string
+                              description: Name of maintainer
+                            repository:
+                              type: string
+                              description: Url of repository
+                            version:
+                              type: number
+                              description: Version number
+                        ParentId:
+                          type: string
+                          description: Parent Id if available
+                        RepoDigests:
+                          type: array
+                          items:
+                            type: string
+                            description: Content addressable identifier
+                        RepoTags:
+                          type: array
+                          items:
+                            type: string
+                            description: Repo tag name
+                        SharedSize:
+                          type: integer
+                          description: Number of shared size
+                        Size:
+                          type: integer
+                          description: Size in bytes
+                        VirtualSize:
+                          type: integer
+                          description: Size in bytes
+              example:
+                status: success
+                data:
+                  - Containers: -1
+                    Created: 1588224617
+                    Id: >-
+                      sha256:8bd1fb3dd2de02f8d4403c657da6a19efeef9286981537b30d2a107079018402
+                    Labels:
+                      description: Unofficial Folding@Home image for CPU compute
+                      maintainer: yurinnick
+                      repository: 'https://github.com/yurinnick/folding-at-home-docker'
+                      version: 7.6
+                  - ParentId: ''
+                    RepoDigests:
+                      - >-
+                        yurinnick/folding-at-home@sha256:da4a32a257883ce5b796482d0f82ec1d1f191056600eb490e1195a65f6100d6d
+                    RepoTags:
+                      - 'yurinnick/folding-at-home:latest'
+                    SharedSize: -1
+                    Size: 85515870
+                    VirtualSize: 85515870
+  /zelapps/installedzelapps:
+    get:
+      tags:
+        - ZelApps
+      summary: installed apps
+      description: Info of installed apps. **Public**
+      operationId: installedZelApps
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        _id:
+                          type: string
+                          description: App id
+                        repotag:
+                          type: string
+                          description: Repository tag
+                        name:
+                          type: string
+                          description: Name of app
+                        port:
+                          type: integer
+                          description: Port number
+                        cpu:
+                          type: number
+                          description: CPU usage
+                        ram:
+                          type: integer
+                          description: Ram usage
+                        hdd:
+                          type: integer
+                          description: Disk usage
+                        enviromentParameters:
+                          type: array
+                          items:
+                            type: string
+                            description: Parameters
+                        commands:
+                          type: array
+                          items:
+                            type: string
+                            description: Parameters
+                        containerPort:
+                          type: integer
+                          description: Port number
+                        containerData:
+                          type: string
+                          description: Dir of container
+              example:
+                status: success
+                data:
+                  - _id: 5ea5ded34640e92141c6ce35
+                    repotag: 'yurinnick/folding-at-home:latest'
+                    name: zelFoldingAtHome
+                    port: 30000
+                    cpu: 0.5
+                    ram: 500
+                    hdd: 15
+                    enviromentParameters:
+                      - USERS=1MQetQGLuSmf6QVvYJFwuSR66WrU47G6NG
+                      - TEAM=262156
+                      - ENABLE_GPU=false
+                      - ENABLE_SMP=true
+                    commands:
+                      - '--allow'
+                      - 0/0
+                      - '--web-allow'
+                      - 0/0
+                    containerPort: 7396
+                    containerData: /config
+  /zelapps/availablezelapps:
+    get:
+      tags:
+        - ZelApps
+      summary: available apps
+      description: Info of available apps. **Public**
+      operationId: availableZelApps
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: App name/id
+                        repotag:
+                          type: string
+                          description: Repository tag
+                        owner:
+                          type: string
+                          description: User's id
+                        timestamp:
+                          type: integer
+                          description: Time stamp in epoch time
+                        validTill:
+                          type: integer
+                          description: Valid time in epoch time
+                        tiered:
+                          type: boolean
+                          description: Tier option
+                        port:
+                          type: integer
+                          description: Port number
+                        cpu:
+                          type: number
+                          description: CPU usage
+                        ram:
+                          type: integer
+                          description: Ram usage
+                        hdd:
+                          type: integer
+                          description: Disk usage
+                        cpubasic:
+                          type: string
+                          description: CPU usage
+                        cpusuper:
+                          type: string
+                          description: CPU usage
+                        cpubamf:
+                          type: string
+                          description: CPU usage
+                        rambasic:
+                          type: integer
+                          description: Ram usage
+                        ramsuper:
+                          type: integer
+                          description: Ram usage
+                        rambamf:
+                          type: integer
+                          description: Ram usage
+                        hddbasic:
+                          type: integer
+                          description: Disk usage
+                        hddsuper:
+                          type: integer
+                          description: Disk usage
+                        hddbamf:
+                          type: integer
+                          description: Disk usage
+                        enviromentParameters:
+                          type: array
+                          items:
+                            type: string
+                            description: Parameters
+                        commands:
+                          type: array
+                          items:
+                            type: string
+                            description: Parameters
+                        containerPort:
+                          type: integer
+                          description: Port number
+                        containerData:
+                          type: string
+                          description: Dir of container
+                        signature:
+                          type: string
+                          description: Signature
+                        txid:
+                          type: string
+                          description: Txid
+              example:
+                status: success
+                data:
+                  - name: zelFoldingAtHome
+                    repotag: 'yurinnick/folding-at-home:latest'
+                    owner: 1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC
+                    timestamp: 1587181519000
+                    validTill: 1608263119000
+                    tiered: true
+                    port: 30000
+                    cpu: 0.5
+                    ram: 500
+                    hdd: 15
+                    cpubasic: 0.5
+                    cpusuper: 1
+                    cpubamf: 2
+                    rambasic: 500
+                    ramsuper: 1000
+                    rambamf: 4000
+                    hddbasic: 15
+                    hddsuper: 15
+                    hddbamf: 15
+                    enviromentParameters:
+                      - USERS=1MQetQGLuSmf6QVvYJFwuSR66WrU47G6NG
+                      - TEAM=262156
+                      - ENABLE_GPU=false
+                      - ENABLE_SMP=true
+                    commands:
+                      - '--allow'
+                      - 0/0
+                      - '--web-allow'
+                      - 0/0
+                    containerPort: 7396
+                    containerData: /config
+                    signature: todo
+                    txid: todo
+  /zelapps/zelshare/getfile:
+    get:
+      tags:
+        - ZelApps
+      summary: Share files
+      description: Call to retrieve share file. **Public**
+      operationId: zelShareFile
+      parameters:
+        - in: query
+          name: file
+          required: true
+          schema:
+            type: string
+          description: File name of share file to view or download
+          example: '?file=message.txt'
+      responses:
+        '200':
+          description: Share file to view/download
+          content:
+            application/file:
+              schema:
+                type: string
+                format: binary
+              example: Hello world
+  /zelapps/zelfluxusage:
+    get:
+      tags:
+        - ZelApps
+      summary: Zelflux's usage
+      description: Will return amount of cpu resource zelflux is using. **Public**
+      operationId: zelFluxUsage
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: number
+                    description: Amount of cpu resource using
+              example:
+                status: success
+                data: 0.20717773
+  /zelapps/zelappsresources:
+    get:
+      tags:
+        - ZelApps
+      summary: Zelflux's usage of resources
+      description: Will return data of resource zelflux is using. **Public**
+      operationId: zelappsResources
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    $ref: '#/components/schemas/zelappsresources'
+              example:
+                status: success
+                data:
+                  zelAppsCpusLocked: 0
+                  zelAppsRamLocked: 0
+                  zelAppsHddLocked: 0
+  /zelapps/zelappstart:
+    get:
+      tags:
+        - ZelApps
+      summary: Starts app
+      description: This will start the zelapp. **ZELTEAM** **ADMIN**
+      operationId: zelAppStart
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: container
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?container=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: ZelApp zelFoldingAtHome successfully started.
+  /zelapps/zelappstop:
+    get:
+      tags:
+        - ZelApps
+      summary: Stops app
+      description: This will stop the zelapp. **ZELTEAM** **ADMIN**
+      operationId: zelAppStop
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: container
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?container=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: ZelApp zelFoldingAtHome successfully stopped.
+  /zelapps/zelapprestart:
+    get:
+      tags:
+        - ZelApps
+      summary: Restarts app
+      description: This will restart the zelapp. **ZELTEAM** **ADMIN**
+      operationId: zelAppRestart
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: container
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?container=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: ZelApp zelFoldingAtHome successfully restarted.
+  /zelapps/zelappkill:
+    get:
+      tags:
+        - ZelApps
+      summary: Kill app
+      description: This will kill the zelapp. **ZELTEAM** **ADMIN**
+      operationId: zelAppKill
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: container
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?container=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: ZelApp zelFoldingAtHome successfully killed.
+  /zelapps/zelappcontainerremove:
+    get:
+      tags:
+        - ZelApps
+      summary: Remove app
+      description: This will remove the zelapp. **ZELTEAM** **ADMIN**
+      operationId: zelAppRemove
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: container
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?container=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: ZelApp zelFoldingAtHome successfully removed.
+  /zelapps/zelapppause:
+    get:
+      tags:
+        - ZelApps
+      summary: Pause app
+      description: This will pause the zelapp. **ZELTEAM** **ADMIN**
+      operationId: zelAppPause
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: container
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?container=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: ZelApp zelFoldingAtHome successfully paused.
+  /zelapps/zelappunpause:
+    get:
+      tags:
+        - ZelApps
+      summary: Unpause app
+      description: This will unpause the zelapp. **ZELTEAM** **ADMIN**
+      operationId: zelAppUnpause
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: container
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?container=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: ZelApp zelFoldingAtHome successfully unpaused.
+  /zelapps/zelapptop:
+    get:
+      tags:
+        - ZelApps
+      summary: List of running processes
+      description: Display the running processes of a container. **ZELTEAM** **ADMIN**
+      operationId: zelAppTop
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: container
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?container=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      processes:
+                        type: array
+                        items:
+                          type: string
+                          description: >-
+                            Each process running in the container, where each is
+                            process is an array of values corresponding to the
+                            titles
+                      Titles:
+                        type: array
+                        items:
+                          type: string
+                          description: The ps column titles
+              example:
+                status: success
+                data:
+                  Processes:
+                    - - 999
+                      - 22001
+                      - 21971
+                      - 0
+                      - 1123
+                      - '?'
+                      - '00:00:00'
+                      - >-
+                        /bin/bash /opt/fahclient/entrypoint.sh --allow 0/0
+                        --web-allow 0/0
+                    - - 999
+                      - 22069
+                      - 22001
+                      - 0
+                      - 1123
+                      - '?'
+                      - '00:00:01'
+                      - >-
+                        /opt/fahclient/FAHClient
+                        --user=1CcoEkKQZcwUXPSps4bZJDjUM3mqe9bNXf --team=262156
+                        --passkey= --gpu=false --smp=true --power=full
+                        --gui-enabled=false --allow 0/0 --web-allow 0/0
+                    - - 999
+                      - 22085
+                      - 22081
+                      - 5
+                      - 1123
+                      - '?'
+                      - >-
+                        /opt/fahclient/cores/cores.foldingathome.org/v7/lin/64bit/avx/Core_a7.fah/FahCore_a7
+                        -dir 00 -suffix 01 -version 706 -lifeline 15 -checkpoint
+                        15 -np 2
+                  Titles:
+                    - UID
+                    - PID
+                    - PPID
+                    - C
+                    - STIME
+                    - TTY
+                    - TIME
+                    - CMD
+  /zelapps/zelapplog:
+    get:
+      tags:
+        - ZelApps
+      summary: App's log
+      description: This will fetch the logs of a zelapp. **ADMIN**
+      operationId: zelAppLogs
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: zelapp
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?zelapp=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: App's log
+              example:
+                status: success
+                data: >-
+                  21:12:16:****************************** FAHClient
+                  ******************************
+
+                  21:12:16:    Version: 7.6.9
+
+                  21:12:16:     Author: Joseph Coffland
+                  <joseph@cauldrondevelopment.com>
+
+                  21:12:16:  Copyright: 2020 foldingathome.org
+
+                  21:12:16:   Homepage: https://foldingathome.org/
+
+                  21:12:16:       Date: Apr 17 2020
+
+                  21:12:16:       Time: 18:11:26
+
+                  21:12:16:   Revision: 398c2b17fa535e0cc6c9d10856b2154c32771646
+
+                  21:12:16:     Branch: master
+
+                  21:12:16:   Compiler: GNU 8.3.0
+
+                  21:12:16:    Options: -std=c++11 -ffunction-sections
+                  -fdata-sections -O3 -funroll-loops
+
+                  21:12:16:             -fno-pie
+
+                  21:12:16:   Platform: linux2 4.19.0-5-amd64
+
+                  21:12:16:       Bits: 64
+
+                  21:12:16:       Mode: Release
+
+                  21:12:16:       Args:
+                  --user=1CcoEkKQZcwUXPSps4bZJDjUM3mqe9bNXf --team=262156
+                  --passkey=
+
+                  21:12:16:             --gpu=false --smp=true --power=full
+                  --gui-enabled=false --allow 0/0
+
+                  21:12:16:             --web-allow 0/0
+
+                  21:12:16:******************************** CBang
+                  ********************************
+
+                  21:12:16:       Date: Apr 17 2020
+
+                  21:12:16:       Time: 18:10:13
+
+                  21:12:16:   Revision: 2fb0be7809c5e45287a122ca5fbc15b5ae859a3b
+
+                  21:12:16:     Branch: master
+
+                  21:12:16:   Compiler: GNU 8.3.0
+
+                  21:12:16:    Options: -std=c++11 -ffunction-sections
+                  -fdata-sections -O3 -funroll-loops
+
+                  21:12:16:             -fno-pie -fPIC
+
+                  21:12:16:   Platform: linux2 4.19.0-5-amd64
+
+                  21:12:16:       Bits: 64
+
+                  21:12:16:       Mode: Release
+
+                  21:12:16:******************************* System
+                  ********************************
+  /zelapps/zelappinspect:
+    get:
+      tags:
+        - ZelApps
+      summary: Info of the app
+      description: Displays detailed info of the container. **ZELTEAM** **ADMIN**
+      operationId: zelAppInspect
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: container
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?container=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      Id:
+                        type: string
+                        description: ID of the container
+                      Created:
+                        type: string
+                        description: Date and time when container was created
+                      Path:
+                        type: string
+                        description: Script path
+                      Args:
+                        type: array
+                        items:
+                          type: string
+                          description: Runtime arguments
+                      State:
+                        type: object
+                        properties:
+                          Status:
+                            type: string
+                            description: State/status of container
+                          Running:
+                            type: boolean
+                            description: Is container running
+                          Paused:
+                            type: boolean
+                            description: Is container paused
+                          Restarting:
+                            type: boolean
+                            description: Is container restarting
+                          OOMKilled:
+                            type: boolean
+                            description: Has memory limit exceeded on container
+                          Dead:
+                            type: boolean
+                            description: Is container dead
+                          Pid:
+                            type: integer
+                            description: Process id
+                          ExitCode:
+                            type: integer
+                            description: Exitcode number
+                          Error:
+                            type: string
+                            description: Description of errors
+                          StartedAt:
+                            type: string
+                            description: Start date and time
+                          FinishedAt:
+                            type: string
+                            description: Finished date and time
+                      Image:
+                        type: string
+                        description: Image id
+                      ResolvConfPath:
+                        type: string
+                        description: Path of containers resolv.conf
+                      HostnamePath:
+                        type: string
+                        description: Path of containers hostname
+                      HostsPath:
+                        type: string
+                        description: Path of hosts
+                      LogPath:
+                        type: string
+                        description: Path of log
+                      Name:
+                        type: string
+                        description: Container name
+                      RestartCount:
+                        type: integer
+                        description: Number of restarts
+                      Driver:
+                        type: string
+                        description: Storage driver type
+                      Platform:
+                        type: string
+                        description: OS type
+                      MountLabel:
+                        type: string
+                        description: Container mount label
+                      ProcessLabel:
+                        type: string
+                        description: Container process label
+                      AppArmorProfile:
+                        type: string
+                        description: Application Armor profile
+                      ExecIDs:
+                        type: string
+                        description: Exec ids of commands
+                      HostConfig:
+                        type: object
+                        properties:
+                          Binds:
+                            type: array
+                            items:
+                              type: string
+                              description: Path to bind directory
+                          ContainerIDFile:
+                            type: string
+                            description: File id
+                          LogConfig:
+                            type: object
+                            properties:
+                              Type:
+                                type: string
+                                description: Log file format type
+                              Config:
+                                type: object
+                                description: Configuration
+                          NetworkMode:
+                            type: string
+                            description: Network mode
+                          PortBindings:
+                            type: object
+                            properties:
+                              7396/tcp:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    HostIp:
+                                      type: string
+                                      description: Ip of host
+                                    HostPort:
+                                      type: integer
+                                      description: Port number
+                          RestartPolicy:
+                            type: object
+                            properties:
+                              Name:
+                                type: string
+                                description: Policy name
+                              MaximumRetryCount:
+                                type: integer
+                                description: Max numbers of restarts
+                          AutoRemove:
+                            type: boolean
+                            description: Is autoremove feature on
+                          VolumeDriver:
+                            type: string
+                            description: Optional volume driver for the container
+                          VolumesFrom:
+                            type: string
+                            description: Mount volumes from the specified container
+                          CapAdd:
+                            type: string
+                            description: Add Linux capabilities
+                          CapDrop:
+                            type: string
+                            description: Drop Linux capabilities
+                          Capabilities:
+                            type: string
+                            description: OS capabilities
+                          Dns:
+                            type: string
+                            description: Set custom DNS servers
+                          DnsOptions:
+                            type: string
+                            description: Set DNS options
+                          DnsSearch:
+                            type: string
+                            description: Set custom DNS search domains
+                          ExtraHosts:
+                            type: string
+                            description: Extra hosts
+                          GroupAdd:
+                            type: string
+                            description: Add additional groups to join
+                          IpcMode:
+                            type: string
+                            description: IPC mode to use
+                          Cgroup:
+                            type: string
+                            description: Cgroup for the container
+                          Links:
+                            type: string
+                            description: Links to another container
+                          OomScoreAdj:
+                            type: integer
+                            description: Tune host's OOM preferences (-1000 to 1000)
+                          PidMode:
+                            type: string
+                            description: Pid to use
+                          Privileged:
+                            type: boolean
+                            description: Extended privileges to this container
+                          PublishAllPorts:
+                            type: boolean
+                            description: Publish all exposed ports to random ports
+                          ReadonlyRootfs:
+                            type: boolean
+                            description: Mount the container’s root filesystem as read only
+                          SecurityOpt:
+                            type: string
+                            description: Security Options
+                          UTSMode:
+                            type: string
+                            description: UTS namespace to use
+                          UsernsMode:
+                            type: string
+                            description: >-
+                              Sets the usernamespace mode for the container when
+                              usernamespace remapping option is enabled
+                          ShmSize:
+                            type: integer
+                            description: Size of /dev/shm
+                          Runtime:
+                            type: string
+                            description: Runtime to use for this container
+                          ConsoleSize:
+                            type: array
+                            items:
+                              type: string
+                              description: >-
+                                Initial console size, as an [height, width]
+                                array. (Windows only)
+                          Isolation:
+                            type: string
+                            description: >-
+                              Isolation technology of the container. (Windows
+                              only)
+                          CpuShares:
+                            type: integer
+                            description: Value containing the container's CPU Shares
+                          Memory:
+                            type: integer
+                            description: Memory limit in bytes
+                          NanoCpus:
+                            type: integer
+                            description: CPU quota in units of 10<sup>-9</sup> CPUs
+                          CgroupParent:
+                            type: string
+                            description: >-
+                              Path to cgroups under which the container's cgroup
+                              is created
+                          BlkioWeight:
+                            type: number
+                            description: Block IO weight (relative weight)
+                          BlkioWeightDevice:
+                            type: string
+                            description: Block IO weight (relative device weight)
+                          BlkioDeviceReadBps:
+                            type: string
+                            description: Limit read rate (bytes per second)
+                          BlkioDeviceWriteBps:
+                            type: string
+                            description: Limit write rate (bytes per second)
+                          BlkioDeviceReadIOps:
+                            type: string
+                            description: Limit read rate (IO per second)
+                          BlkioDeviceWriteIOps:
+                            type: string
+                            description: Limit write rate (IO per second)
+                          CpuPeriod:
+                            type: integer
+                            description: The length of a CPU period in microseconds
+                          CpuQuota:
+                            type: integer
+                            description: >-
+                              Microseconds of CPU time that the container can
+                              get in a CPU period
+                          CpuRealtimePeriod:
+                            type: integer
+                            description: CPU real-time period limit in microseconds
+                          CpuRealtimeRuntime:
+                            type: integer
+                            description: CPU real-time runtime limit in microseconds
+                          CpusetCpus:
+                            type: string
+                            description: CPUs in which to allow execution
+                          CpusetMems:
+                            type: string
+                            description: >-
+                              Memory nodes (MEMs) in which to allow execution
+                              (0-3, 0,1). Only effective on NUMA systems
+                          Devices:
+                            type: string
+                            description: A list of devices to add to the container
+                          DeviceCgroupRules:
+                            type: string
+                            description: A list of cgroup rules to apply to the container
+                          DeviceRequests:
+                            type: string
+                            description: >-
+                              A list of requests for devices to be sent to
+                              device drivers
+                          KernelMemory:
+                            type: integer
+                            description: Kernel memory limit
+                          KernelMemoryTCP:
+                            type: integer
+                            description: Hard limit for kernel TCP buffer memory (in bytes)
+                          MemoryReservation:
+                            type: integer
+                            description: Memory soft limit in bytes
+                          MemorySwap:
+                            type: integer
+                            description: >-
+                              Swap limit equal to memory plus swap: -1 to enable
+                              unlimited swap
+                          MemorySwappiness:
+                            type: string
+                            description: Container's memory swappiness behavior
+                          OomKillDisable:
+                            type: boolean
+                            description: >-
+                              Whether to disable OOM Killer for the container or
+                              not
+                          PidsLimit:
+                            type: integer
+                            description: Container's pids limit. Set -1 for unlimited.
+                          Ulimits:
+                            type: array
+                            items:
+                              type: object
+                              description: >-
+                                A list of resource limits to set in the
+                                container
+                              properties:
+                                Name:
+                                  type: string
+                                Hard:
+                                  type: integer
+                                Soft:
+                                  type: integer
+                          CpuCount:
+                            type: integer
+                            description: The number of usable CPUs (Windows only)
+                          CpuPercent:
+                            type: integer
+                            description: >-
+                              The usable percentage of the available CPUs
+                              (Windows only)
+                          IOMaximumIOps:
+                            type: integer
+                            description: >-
+                              Maximum IOps for the container system drive
+                              (Windows only)
+                          IOMaximumBandwidth:
+                            type: integer
+                            description: >-
+                              Maximum IO in bytes per second for the container
+                              system drive
+                          MaskedPaths:
+                            type: array
+                            items:
+                              type: string
+                              description: >-
+                                The list of paths to be masked inside the
+                                container
+                          ReadonlyPaths:
+                            type: array
+                            items:
+                              type: string
+                              description: >-
+                                The list of paths to be set as read-only inside
+                                the container
+                      GraphDriver:
+                        type: object
+                        description: Information about a container's graph driver
+                        properties:
+                          Data:
+                            type: object
+                            properties:
+                              LowerDir:
+                                type: string
+                              MergedDir:
+                                type: string
+                              UpperDir:
+                                type: string
+                              WorkDir:
+                                type: string
+                          Name:
+                            type: string
+                      Mounts:
+                        $ref: '#/components/schemas/mounts'
+                      Config:
+                        type: object
+                        properties:
+                          Hostname:
+                            type: string
+                            description: >-
+                              The hostname to use for the container, as a valid
+                              RFC 1123 hostname
+                          Domainname:
+                            type: string
+                            description: The domain name to use for the container
+                          User:
+                            type: string
+                            description: >-
+                              The user that commands are run as inside the
+                              container
+                          AttachStdin:
+                            type: boolean
+                            description: Whether to attach to stdin
+                          AttachStdout:
+                            type: boolean
+                            description: Whether to attach to stdout
+                          AttachStderr:
+                            type: boolean
+                            description: Whether to attach to stderr
+                          ExposedPorts:
+                            type: object
+                            description: An object mapping ports to an empty object
+                            additionalProperties:
+                              type: object
+                              enum:
+                                - {}
+                              default: {}
+                          Tty:
+                            type: boolean
+                            description: >-
+                              Attach standard streams to a TTY, including stdin
+                              if it is not closed
+                          OpenStdin:
+                            type: boolean
+                            description: Open stdin
+                          StdinOnce:
+                            type: boolean
+                            description: Close stdin after one attached client disconnects
+                          Env:
+                            type: array
+                            items:
+                              type: string
+                              description: >-
+                                A list of environment variables to set inside
+                                the container
+                          Cmd:
+                            type: array
+                            items:
+                              type: string
+                              description: >-
+                                Command to run specified as a string or an array
+                                of strings
+                          Image:
+                            type: string
+                            description: >-
+                              The name of the image to use when creating the
+                              container
+                          Volumes:
+                            type: object
+                            description: >-
+                              An object mapping mount point paths inside the
+                              container to empty objects
+                            additionalProperties:
+                              type: object
+                              enum:
+                                - {}
+                              default: {}
+                          WorkingDir:
+                            type: string
+                            description: The working directory for commands to run in
+                          Entrypoint:
+                            type: array
+                            items:
+                              type: string
+                              description: >-
+                                The entry point for the container as a string or
+                                an array of strings
+                          OnBuild:
+                            type: string
+                            description: >-
+                              ONBUILD metadata that were defined in the image's
+                              Dockerfile
+                          Labels:
+                            type: object
+                            description: User-defined key/value metadata
+                            properties:
+                              description:
+                                type: string
+                              maintainer:
+                                type: string
+                              repository:
+                                type: string
+                              version:
+                                type: string
+                      NetworkSettings:
+                        type: object
+                        description: >-
+                          NetworkSettings exposes the network settings in the
+                          API
+                        properties:
+                          Bridge:
+                            type: string
+                            description: Name of the network's bridge
+                          SandboxID:
+                            type: string
+                            description: >-
+                              SandboxID uniquely represents a container's
+                              network stack
+                          HairpinMode:
+                            type: boolean
+                            description: >-
+                              Indicates if hairpin NAT should be enabled on the
+                              virtual interface
+                          LinkLocalIPv6Address:
+                            type: string
+                            description: IPv6 unicast address using the link-local prefix
+                          LinkLocalIPv6PrefixLen:
+                            type: integer
+                            description: Prefix length of the IPv6 unicast address
+                          Ports:
+                            type: object
+                            description: >-
+                              PortMap describes the mapping of container ports
+                              to host ports, using the container's port-number
+                              and protocol as key. If a container's port is
+                              mapped for multiple protocols, separate entries
+                              are added to the mapping table.
+                            additionalProperties:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  HostIp:
+                                    type: string
+                                    description: >-
+                                      Host IP address that the container's port
+                                      is mapped to
+                                  HostPort:
+                                    type: string
+                                    description: >-
+                                      Host port number that the container's port
+                                      is mapped to
+                          SandboxKey:
+                            type: string
+                            description: SandboxKey identifies the sandbox
+                          SecondaryIPAddresses:
+                            type: array
+                            items:
+                              type: object
+                              description: Address represents an IPv4 or IPv6 IP address
+                              properties:
+                                Addr:
+                                  type: string
+                                  description: IP address
+                                PrefixLen:
+                                  type: integer
+                                  description: Mask length of the IP address
+                          SecondaryIPv6Addresses:
+                            type: array
+                            items:
+                              type: object
+                              description: Address represents an IPv4 or IPv6 IP address
+                              properties:
+                                Addr:
+                                  type: string
+                                  description: IP address
+                                PrefixLen:
+                                  type: integer
+                                  description: Mask length of the IP address
+                          EndpointID:
+                            type: string
+                            description: >-
+                              EndpointID uniquely represents a service endpoint
+                              in a Sandbox
+                          Gateway:
+                            type: string
+                            description: Gateway address for the default "bridge" network
+                          GlobalIPv6Address:
+                            type: string
+                            description: >-
+                              Global IPv6 address for the default "bridge"
+                              network
+                          GlobalIPv6PrefixLen:
+                            type: integer
+                            description: Mask length of the global IPv6 address
+                          IPAddress:
+                            type: string
+                            description: IPv4 address for the default "bridge" network
+                          IPPrefixLen:
+                            type: integer
+                            description: Mask length of the IPv4 address
+                          IPv6Gateway:
+                            type: string
+                            description: IPv6 gateway address for this network
+                          MacAddress:
+                            type: string
+                            description: >-
+                              MAC address for the container on the default
+                              "bridge" network
+                          Networks:
+                            type: object
+                            description: >-
+                              Information about all networks that the container
+                              is connected to
+                            properties:
+                              zelfluxDockerNetwork:
+                                $ref: '#/components/schemas/zelfluxnetwork'
+              example:
+                status: success
+                data:
+                  Id: >-
+                    3cf131c856714g2s877r711931faa6622fe5aa9345fa392cbef54e5b9483c6a1
+                  Created: '2020-05-16T16:40:36.11971926Z'
+                  Path: /opt/fahclient/entrypoint.sh
+                  Args:
+                    - '--allow'
+                    - 0/0
+                    - '--web-allow'
+                    - 0/0
+                  State:
+                    Status: paused
+                    Running: true
+                    Paused: true
+                    Restarting: false
+                    OOMkilled: false
+                    Dead: false
+                    Pid: 22001
+                    ExitCode: 0
+                    Error: ''
+                    StartedAt: '2020-05-16T16:43:53.607846737Z'
+                    FinishedAt: '2020-05-16T16:42:21.220760109Z'
+                  Image: >-
+                    sha256:8bd1fb3dd2de02f8d4403c657da6a19efeef9286981537b30d2a107079018402
+                  ResolvConfPath: >-
+                    /var/lib/docker/containers/3cf131c856714g2s877r711931faa6622fe5aa9345fa392cbef54e5b9483c6a1/resolv.conf
+                  HostnamePath: >-
+                    /var/lib/docker/containers/3cf131c856714g2s877r711931faa6622fe5aa9345fa392cbef54e5b9483c6a1/hostname
+                  HostsPath: >-
+                    /var/lib/docker/containers/3cf131c856714g2s877r711931faa6622fe5aa9345fa392cbef54e5b9483c6a1/hosts
+                  LogPath: >-
+                    /var/lib/docker/containers/3cf131c856714g2s877r711931faa6622fe5aa9345fa392cbef54e5b9483c6a1/3cf131c856714g2s877r711931faa6622fe5aa9345fa392cbef54e5b9483c6a1-json.log
+                  Name: /zelFoldingAtHome
+                  RestartCount: 0
+                  Driver: overlay2
+                  Platform: linux
+                  MountLabel: ''
+                  ProcessLabel: ''
+                  AppArmorProfile: docker-default
+                  ExecIDs: null
+                  HostConfig:
+                    Binds:
+                      - '/home/zel/zelflux/ZelApps/zelFoldingAtHome:/config'
+                    ContainerIDFile: ''
+                    LogConfig:
+                      Type: json-file
+                      Config: {}
+                    NetworkMode: zelfluxDockerNetwork
+                    PortBindings:
+                      7396/tcp:
+                        - HostIp: ''
+                          HostPort: 30000
+                    RestartPolicy:
+                      Name: unless-stopped
+                      MaximumRetryCount: 0
+                    AutoRemove: false
+                    VolumeDriver: ''
+                    VolumesFrom: null
+                    CapAdd: null
+                    CapDrop: null
+                    Capabilities: null
+                    Dns: null
+                    DnsOptions: null
+                    DnsSearch: null
+                    ExtraHosts: null
+                    GroupAdd: null
+                    IpcMode: private
+                    Cgroup: ''
+                    Links: null
+                    OomScoreAdj: 0
+                    PidMode: ''
+                    Privileged: false
+                    PublishAllPorts: false
+                    SecurityOpt: null
+                    UTSMode: ''
+                    UsernsMode: ''
+                    ShmSize: 67108864
+                    Runtime: runc
+                    ConsoleSize:
+                      - 0
+                      - 0
+                    Isolation: ''
+                    CpuShares: 0
+                    Memory: 524288000
+                    NanoCpus: 500000000
+                    CgroupParent: ''
+                    BlkioWeight: null
+                    BlkioWeightDevice: null
+                    BlkioDeviceReadBps: null
+                    BlkioDeviceWriteBps: null
+                    BlkioDeviceReadIOps: null
+                    BlkioDeviceWriteIOps: null
+                    CpuPeriod: 0
+                    CpuQuota: 0
+                    CpuRealtimePeriod: 0
+                    CpuRealtimeRuntime: 0
+                    CpusetCpus: ''
+                    CpusetMems: ''
+                    Devices: null
+                    DeviceCgroupRules: null
+                    DeviceRequests: null
+                    KernelMemory: 0
+                    KernelMemoryTCP: 0
+                    MemoryReservation: 0
+                    MemorySwap: -1
+                    MemorySwappiness: null
+                    OomKillDisable: false
+                    PidsLimit: null
+                    Ulimits:
+                      - Name: nofile
+                        Hard: 16384
+                        Soft: 8192
+                    CpuCount: 0
+                    CpuPercent: 0
+                    IOMaximumIOps: 0
+                    IOMaximumBandwidth: 0
+                    MaskedPaths:
+                      - /proc/asound
+                      - /proc/acpi
+                      - /proc/kcore
+                      - /proc/keys
+                      - /proc/latency_stats
+                      - /proc/timer_list
+                      - /proc/timer_stats
+                      - /proc/sched_debug
+                      - /proc/scsi
+                      - /sys/firmware
+                    ReadonlyPaths:
+                      - /proc/bus
+                      - /proc/fs
+                      - /proc/irq
+                      - /proc/sys
+                      - /proc/sysrq-trigger
+                  GraphDriver:
+                    Data:
+                      LowerDir: >-
+                        /var/lib/docker/overlay2/ddd72fca4ad0e998d127g587463fed04d0927e364d3e5627cdc1860752fdf3d963-init/diff:/var/lib/docker/overlay2/37f925753b6ff671205ad58326379748c1ec9124ada87615bd18a76d7f538e9f/diff:/var/lib/docker/overlay2/f09d20a3b3010cf03adc8a99651adc3cecd33ed8bce8915f1e29c266d78801c5/diff:/var/lib/docker/overlay2/1be67c986305e14d788b8787651cd7bb90b9398adaf94fe287dbf07661eaca0d/diff:/var/lib/docker/overlay2/66d7763a8fc1b81c5c63ab187db968b74t26e3bc2a25d2d8039cac0971fdb9ed/diff
+                      MergedDir: >-
+                        /var/lib/docker/overlay2/ddd72fca4ad0e998f98a48463fed04d0927e364d3e5627cdc1860752fdf3d963/merged
+                      UpperDir: >-
+                        /var/lib/docker/overlay2/ddd72fca4ad0e998d127g587463fed04d0927e364d3e5627cdc1860752fdf3d963/diff
+                      WorkDir: >-
+                        /var/lib/docker/overlay2/ddd72fca4ad0e998d127g587463fed04d0927e364d3e5627cdc1860752fdf3d963/work
+                    Name: overlay2
+                  Mounts:
+                    - Type: bind
+                      Source: /home/zel/zelflux/ZelApps/zelFoldingAtHome
+                      Destination: /config
+                      Mode: ''
+                      RW: true
+                      Propagation: rprivate
+                  Config:
+                    Hostname: 3cf131c85671
+                    Domainname: ''
+                    User: folding
+                    AttachStdin: true
+                    AttachStdout: true
+                    AttachStderr: true
+                    ExposedPorts:
+                      36330/tcp: {}
+                      7396/tcp: {}
+                    Tty: false
+                    OpenStdin: false
+                    StdinOnce: false
+                    Env:
+                      - USER=1CcoEkKQZcwUXPSps4bZJDjUM3mqe9bNXf
+                      - TEAM=262156
+                      - ENABLE_GPU=false
+                      - ENABLE_SMP=true
+                      - >-
+                        PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+                      - POWER=full
+                    Cmd:
+                      - '--allow'
+                      - 0/0
+                      - '--web-allow'
+                      - 0/0
+                    Image: 'yurinnick/folding-at-home:latest'
+                    Volumes: null
+                    WorkingDir: /opt/fahclient
+                    Entrypoint:
+                      - /opt/fahclient/entrypoint.sh
+                    OnBuild: null
+                    Labels:
+                      description: Unofficial Folding@Home image for CPU compute
+                      maintainer: yurinnick
+                      repository: 'https://github.com/yurinnick/folding-at-home-docker'
+                      version: 7.6
+                  NetworkSettings:
+                    Bridge: ''
+                    SandboxID: asdf1234hjkl5678
+                    HairpinMode: false
+                    LinkLocalIPv6Address: ''
+                    LinkLocalIPv6PrefixLen: 0
+                    Ports:
+                      36330/tcp: null
+                      7396/tcp:
+                        - HostIp: 0.0.0.0
+                          HostPort: 30000
+                    SandboxKey: /var/run/docker/netns/asdf1234hjkl
+                    SecondaryIPAddresses: null
+                    SecondaryIPv6Addresses: null
+                    EndpointID: ''
+                    Gateway: ''
+                    GlobalIPv6Address: ''
+                    GlobalIPv6PrefixLen: ''
+                    IPAddress: ''
+                    IPPrefixLen: 0
+                    IPv6Gateway: ''
+                    MacAddress: ''
+                    Networks:
+                      zelfluxDockerNetwork:
+                        IPAMConfig: null
+                        Links: null
+                        Aliases:
+                          - 1278j8c85671
+                        NetworkID: >-
+                          1aae1cddff7c12875a99b0c0be79835d74f5e23cdafdaf3fb20addb782795c4
+                        EndpointID: >-
+                          a94a5e37af12398fce10312e2060891d026231e1270d5f4163d2bfb06fe32137
+                        Gateway: 143.17.0.1
+                        IPAddress: 143.17.0.1
+                        IPPrefixLen: 16
+                        IPv6Gateway: ''
+                        GlobalIPv6Address: ''
+                        GlobalIPv6PrefixLen: 0
+                        MacAddress: '02.34:ac:11:01:06'
+                        DriverOpts: null
+  /zelapps/zelappupdate:
+    get:
+      tags:
+        - ZelApps
+      summary: Update app
+      description: This will update the zelapp cpu and mem usage. **ZELTEAM** **ADMIN**
+      operationId: zelAppUpdate
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: container
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?container=zelFoldingAtHome'
+        - in: query
+          name: cpus
+          required: true
+          schema:
+            type: string
+          description: Cpu core count
+          example: '?container=...&cpus=2'
+        - in: query
+          name: memory
+          required: true
+          schema:
+            type: string
+          description: Memory in bytes
+          example: '?container=...&memory=5000000'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      Warnings:
+                        type: array
+                        items:
+                          type: string
+                          description: Explanation of warning
+              example:
+                status: success
+                data:
+                  Warnings: null
+  /zelapps/zelappremove:
+    get:
+      tags:
+        - ZelApps
+      summary: Clean and remove container
+      description: >-
+        This will stop, clean data, close port, and remove the container.
+        **ZELTEAM** **ADMIN**
+      operationId: removeZelAppLocally
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: zelapp
+          required: true
+          schema:
+            type: string
+          description: Name/Id of app
+          example: '?zelapp=zelFoldingAtHome'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Status of the cleanup in progress
+              example:
+                status: success
+                data: ZelApp zelFoldingAtHome was successfuly removed
+  /zelapps/createzelfluxnetwork:
+    get:
+      tags:
+        - ZelApps
+      summary: Create flux network
+      description: This will create flux network if none is detected. **ZELTEAM** **ADMIN**
+      operationId: createZelFluxNetwork
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Flux Network already exists.
+  /zelapps/zelappimageremove:
+    get:
+      tags:
+        - ZelApps
+      summary: Remove app image
+      description: Remove app image installed. **ZELTEAM** **ADMIN**
+      operationId: zelAppImageRemove
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: image
+          required: true
+          schema:
+            type: string
+          description: Id of image
+          example: >-
+            ?image=sha256:c524341a8884a3b612121c6fea1772ba0e4abe4d59013390a8732bb724e691d3
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: >-
+                  ZelApp
+                  sha256:c524341a8884a3b612121c6fea1772ba0e4abe4d59013390a8732bb724e691d3
+                  image successfully removed.
+  /explorer/zelnodetxs:
+    get:
+      tags:
+        - Explorer
+      summary: View ZelNode transactions
+      description: View a filtered list of the ZelNode's transactions. **PUBLIC**
+      operationId: getFilteredZelNodeTxs
+      parameters:
+        - in: query
+          name: filter
+          required: true
+          schema:
+            type: string
+          description: 'Filter using Ip, Zel address, or Collateral hash'
+          example: '?filter=47.22.47.180'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      txid:
+                        type: string
+                        description: The transaction id
+                      version:
+                        type: integer
+                        description: Version number
+                      type:
+                        type: string
+                        description: Type of transaction
+                      updateType:
+                        type: integer
+                        description: Update type number
+                      ip:
+                        type: string
+                        description: Ip of zelnode's server
+                      benchTier:
+                        type: string
+                        description: Zelnode tier
+                      collateralHash:
+                        type: string
+                        description: Collateral tx hash
+                      collateralIndex:
+                        type: integer
+                        description: Collateral tx output index
+                      zelAddress:
+                        type: string
+                        description: Zel address
+                      lockedAmount:
+                        type: integer
+                        description: Locked amount in satoshi value
+                      height:
+                        type: integer
+                        description: Block height tx was included in
+              example:
+                status: success
+                data:
+                  txid: >-
+                    793dc163a52f445ebeaa838d8d23b22ebd7c1b1d990c450a52f00ff1825c1368
+                  version: 5
+                  type: Confirming a zelnode
+                  updateType: 1
+                  ip: 47.22.47.180
+                  benchTier: SUPER
+                  collateralHash: >-
+                    1216fd06c889aa3c559739f0ad6756a6a03700dd0590749a58868ad90a116f13
+                  collateralIndex: 0
+                  zelAddress: t1YVyS1StV318tubSwiwMtfw9BLLo8RGwK2
+                  lockedAmount: 2500000000000
+                  height: 575023
+  /explorer/utxo:
+    get:
+      tags:
+        - Explorer
+      summary: View utxo history
+      description: View unspent transaction outputs of selected address. **PUBLIC**
+      operationId: getAddressUtxos
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema:
+            type: string
+          description: Zel address to look up utxo's
+          example: '?address=t1edbnsYnGXxyYNt4kJJPhZktDWNaKwkznY'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        txid:
+                          type: string
+                          description: The transaction id
+                        voutIndex:
+                          type: integer
+                          description: Vout index of the transaction
+                        height:
+                          type: integer
+                          description: Block height of transaction
+                        address:
+                          type: string
+                          description: Zel address
+                        satoshis:
+                          type: integer
+                          description: Value of Zel in satoshi
+                        scriptPubKey:
+                          type: string
+                          description: Script public key
+                        coinbase:
+                          type: boolean
+                          description: If coinbase or not
+              example:
+                status: success
+                data:
+                  - txid: >-
+                      dc7113577d1ccf539032c4e0155a3099fdc227d8c26ee0191628735c2b4cf4dc
+                    voutIndex: 2
+                    height: 288132
+                    address: t1edbnsYnGXxyYNt4kJJPhZktDWNaKwkznY
+                    satoshis: 10011373238
+                    scriptPubKey: 76a914e3b4a37c811d29cead34b20a67baeed714b415e388ac
+                    coinbase: false
+                  - txid: >-
+                      f9315e66c62bd356973d3fd63ace4d6327dbcf26a4d084d50ff3ec0441577196
+                    voutIndex: 0
+                    height: 288287
+                    address: t1edbnsYnGXxyYNt4kJJPhZktDWNaKwkznY
+                    satoshis: 10315062273
+                    scriptPubKey: 76a914e3b4a37c811d29cead34b20a67baeed714b415e388ac
+                    coinbase: false
+  /explorer/transactions:
+    get:
+      tags:
+        - Explorer
+      summary: View transaction history
+      description: View transaction history of selected address. **PUBLIC**
+      operationId: getAddressTransactions
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema:
+            type: string
+          description: Zel address to look up tx history
+          example: '?address=t1edbnsYnGXxyYNt4kJJPhZktDWNaKwkznY'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      address:
+                        type: string
+                        description: Zel address
+                      transactions:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            txid:
+                              type: string
+                              description: The transaction id
+                            height:
+                              type: integer
+                              description: Block height of transaction
+              example:
+                status: success
+                data:
+                  address: t1edbnsYnGXxyYNt4kJJPhZktDWNaKwkznY
+                  transactions:
+                    - txid: >-
+                        5120e5e0a4129f26ccd630710697219f482148aabddf47f2e0ebc212e3e18cbd
+                      height: 253301
+                    - txid: >-
+                        1ffe6f5b8b15fbcbd5dfc6b9f0f1d6fc02aae4434bbf45705fa96ad56c47d6e1
+                      height: 253302
+                    - txid: >-
+                        2dbd48d70af588b3781acc2763fab1d2515b3d508d89e4cd20e34f911cd9085a
+                      height: 253828
+  /explorer/balance:
+    get:
+      tags:
+        - Explorer
+      summary: View balance
+      description: View balance of selected address. **PUBLIC**
+      operationId: getAddressBalance
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema:
+            type: string
+          description: Zel address to look up balance
+          example: '?address=t1edbnsYnGXxyYNt4kJJPhZktDWNaKwkznY'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: integer
+                    description: Zel balance in satoshi value
+              example:
+                status: success
+                data: 7089180145154
+  /explorer/scannedheight:
+    get:
+      tags:
+        - Explorer
+      summary: View scanned block height
+      description: View scanned block height on the explorer that it has synced. **PUBLIC**
+      operationId: getScannedHeight
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: object
+                    properties:
+                      generalScannedHeight:
+                        type: integer
+                        description: Block height
+              example:
+                status: success
+                data:
+                  generalScannedHeight: 593977
+  /explorer/reindex:
+    get:
+      tags:
+        - Explorer
+      summary: Reindex collection
+      description: Drop ZelCash collection and recreate it. **ZELTEAM** **ADMIN**
+      operationId: reindexExplorer
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Explorer database reindex initiated
+  /explorer/restart:
+    get:
+      tags:
+        - Explorer
+      summary: Restart block processing
+      description: Restarts ZelCash collection. **ZELTEAM** **ADMIN**
+      operationId: restartBlockProcessing
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Block processing initiated
+  /explorer/stop:
+    get:
+      tags:
+        - Explorer
+      summary: Stops block processing
+      description: Stops ZelCash collection. **ZELTEAM** **ADMIN**
+      operationId: stopBlockProcessing
+      security:
+        - ZelID: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Block processing is stopped
+  /explorer/rescan:
+    get:
+      tags:
+        - Explorer
+      summary: Rescan explorer
+      description: Rescan explorer from selected block height. **ZELTEAM** **ADMIN**
+      operationId: rescanExplorer
+      security:
+        - ZelID: []
+      parameters:
+        - in: query
+          name: blockheight
+          required: true
+          schema:
+            type: integer
+          description: Block height to start rescan from
+          example: '?blockheight=585000'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/status'
+                  data:
+                    type: string
+                    description: Explanation of status
+              example:
+                status: success
+                data: Explorer rescan from blockheight 585000 initiated
 components:
   schemas:
     signature:
-      description: Signature of signed loginPhrase with zelid
+      description: Signature of signed loginPhrase with zelid.
       type: string
-      example: H+ZB3oSrsw6XkBxxlbwk33LEBJYvqtbMIm2kL9JzuoXMC6pSZd0lBHdnhJYzMTXv81zZQ7G/pkK1NvYN7cNF0GE=
+      example: >-
+        H+ZB3oSrsw6XkBxxlbwk33LEBJYvqtbMIm2kL9JzuoXMC6pSZd0lBHdnhJYzMTXv81zZQ7G/pkK1NvYN7cNF0GE=
     ZelIDLogin:
       type: object
       properties:
         loginPhrase:
-          description: Login Phrase. Provided by GET /zelid/loginphrase
+          description: Login Phrase. Provided by GET /zelid/loginphrase.
           type: string
           minLength: 40
           example: 1574991374806spbcvsuwerl52tppx9dw5khuz8rew13mkq86gg8r2c
         zelid:
-          description: ZelID or any P2PKH bitcoin address
+          description: ZelID or any P2PKH bitcoin address.
           type: string
           minLength: 26
           maxLength: 35
@@ -634,7 +12303,7 @@ components:
     ErrorMessage:
       type: object
       properties:
-        status: 
+        status:
           type: string
           description: error
         data:
@@ -651,19 +12320,783 @@ components:
               description: message of error
     status:
       type: string
-      description: status
-      enum: [success, error]
-      
+      description: Explanation of status
+      enum:
+        - success
+        - error
+    nullmessage:
+      type: string
+      description: Null. Status will return with success if call/command was successful.
+    statusmessage:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Explanation of status
+    benchstatus:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Status of server
+        benchmarking:
+          type: string
+          description: Tier server passed for BASIC/SUPER/BAMF
+        zelback:
+          type: string
+          description: Status of ZelFlux backend
+    benchinfo:
+      type: object
+      properties:
+        version:
+          type: string
+          description: Version number
+        rpcport:
+          type: integer
+          description: Rpc port number
+    createmultisig:
+      type: object
+      properties:
+        address:
+          type: string
+          description: The value of the new multisig address
+        redeemScript:
+          type: string
+          description: The string value of the hex-encoded redemption script
+    decodescript:
+      type: object
+      properties:
+        asm:
+          type: string
+          description: Script public key
+        reqSigs:
+          type: integer
+          description: The required signatures
+        type:
+          type: string
+          description: The output type
+        addresses:
+          type: array
+          items:
+            type: string
+            description: Zelcash address
+        p2sh:
+          type: string
+          description: Script address
+    decoderawtransaction:
+      type: object
+      properties:
+        txid:
+          type: string
+          description: The transaction id
+        version:
+          type: integer
+          description: The version
+        overwintered:
+          type: boolean
+          description: The Overwintered flag
+        versiongroupid:
+          type: string
+          description: The version group id
+        locktime:
+          type: integer
+          description: The lock time
+        expiryheight:
+          type: integer
+          description: Last valid block height for mining transaction
+        vin:
+          type: array
+          items:
+            type: object
+            properties:
+              txid:
+                type: string
+                description: The transaction id
+              vout:
+                type: integer
+                description: The output index
+              scriptSig:
+                type: object
+                properties:
+                  asm:
+                    type: string
+                    description: Script public key
+                  hex:
+                    type: string
+                    description: The hex
+              sequence:
+                type: integer
+                description: The script sequence number
+        vout:
+          $ref: '#/components/schemas/vout'
+        vJoinSplit:
+          $ref: '#/components/schemas/joinsplit'
+        valueBalance:
+          type: number
+          description: The balance value of ZEL
+        valueBalanceZat:
+          type: number
+          description: The balance value of ZEL
+        vShieldedSpend:
+          $ref: '#/components/schemas/shieldedspend'
+        vShieldedOutput:
+          $ref: '#/components/schemas/shieldedoutput'
+    fundrawtransaction:
+      type: object
+      properties:
+        hex:
+          type: string
+          description: The resulting raw transaction
+        changepos:
+          type: integer
+          description: 'The position of the added change output, or -1'
+        fee:
+          type: number
+          description: The fee added to the transaction
+    getbenchmarks:
+      type: object
+      properties:
+        ipaddress:
+          type: string
+          description: Ip address of ZelNode server
+        status:
+          type: string
+          description: BASIC/SUPER/BAMF
+        time:
+          type: integer
+          description: Time of bench in epoch time
+        cores:
+          type: integer
+          description: The amount of cores detected
+        ram:
+          type: number
+          description: The amount of ram detected
+        ssd:
+          type: number
+          description: The amount of ssd space detected
+        hdd:
+          type: number
+          description: The amount of hdd space detected
+        dd_write:
+          type: number
+          description: The amount of write speed detected
+        eps:
+          type: number
+          description: The amount of cpu speed detected
+    joinsplit:
+      type: array
+      items:
+        type: object
+        description: This is related to sprout tx's
+        properties:
+          vpub_old:
+            type: number
+            description: Public input value of ZEL
+          vpub_oldZat:
+            type: integer
+            description: Public input value of ZEL in satoshis
+          vpub_new:
+            type: number
+            description: Public output of ZEL
+          vpub_newZat:
+            type: integer
+            description: Public output of ZEL in satoshis
+          anchor:
+            type: string
+            description: Merkle root of note commitment tree
+          nullifiers:
+            type: array
+            items:
+              type: string
+              description: Input note nullifier
+          commitments:
+            type: array
+            items:
+              type: string
+              description: Output note commitment
+          onetimePubKey:
+            type: string
+            description: The onetime public key used to encrypt the cipertexts
+          randomSeed:
+            type: string
+            description: The random seed
+          macs:
+            type: array
+            items:
+              type: string
+              description: Input note MAC
+          proof:
+            type: string
+            description: The zero-knowledge proof
+          ciphertexts:
+            type: array
+            items:
+              type: string
+              description: Output note ciphertext
+    listtransactions:
+      type: array
+      items:
+        type: object
+        properties:
+          account:
+            type: string
+            description: >-
+              The account name associated with the transaction. Will be "" for
+              the default account
+          address:
+            type: string
+            description: >-
+              The Zelcash address of the transaction. Not present for move
+              transactions (category = move)
+          category:
+            type: string
+            description: >-
+              The transaction category. 'send' has negative amounts, 'receive'
+              has positive amounts
+          amount:
+            type: number
+            description: >-
+              The amount in ZEL. This is negative for the 'send' category, and
+              for the 'move' category for moves outbound. It is positive for the
+              'receive' category, and for the 'move' category for inbound funds.
+          vout:
+            type: integer
+            description: Vout value
+          fee:
+            type: number
+            description: >-
+              The number of confirmations for the transaction. Available for
+              'send' and 'receive' category of transactions
+          confirmations:
+            type: integer
+            description: >-
+              The number of confirmations for the transaction. Available for
+              'send' and 'receive' category of transactions
+          blockhash:
+            type: string
+            description: >-
+              The block hash containing the transaction. Available for 'send'
+              and 'receive' category of transactions
+          blockindex:
+            type: integer
+            description: >-
+              The block index containing the transaction. Available for 'send'
+              and 'receive' category of transactions
+          blocktime:
+            type: integer
+            description: The block time in seconds since epoch (1 Jan 1970 GMT)
+          expiryheight:
+            type: integer
+            description: Expiry height of transaction
+          txid:
+            type: string
+            description: >-
+              The transaction id. Available for 'send' and 'receive' category of
+              transactions
+          walletconflicts:
+            $ref: '#/components/schemas/walletconflicts'
+          time:
+            type: integer
+            description: The transaction time in seconds since epoch (Jan 1 1970 GMT)
+          timereceived:
+            type: integer
+            description: The time received in seconds since epoch (Jan 1 1970 GMT)
+          vJoinSplit:
+            $ref: '#/components/schemas/joinsplit'
+          size:
+            type: integer
+            description: Size in bytes
+    shieldedoutput:
+      type: array
+      items:
+        type: object
+        properties:
+          cv:
+            type: string
+            description: Output cv note
+          cmu:
+            type: string
+            description: Output cmu note
+          ephemeralKey:
+            type: string
+            description: The ephemeral key
+          encCiphertext:
+            type: string
+            description: The encrypted ciphertext
+          outCiphertext:
+            type: string
+            description: Output note ciphertext
+          proof:
+            type: string
+            description: The zero-knowledge proof
+    shieldedspend:
+      type: array
+      items:
+        type: object
+        properties:
+          cv:
+            type: string
+            description: The cv note encryption
+          anchor:
+            type: string
+            description: Merkle root of note commitment tree
+          nullifier:
+            type: string
+            description: The nullifier
+          rk:
+            type: string
+            description: The prover key
+          proof:
+            type: string
+            description: The proof
+          spendAuthSig:
+            type: string
+            description: The spend signature
+    signrawtransaction:
+      type: object
+      properties:
+        hex:
+          type: string
+          description: The hex-encoded raw transaction with signatures
+        complete:
+          type: boolean
+          description: If the transaction has a complete set of signatures
+        errors:
+          type: object
+          description: Script verification errors (if there are any)
+          properties:
+            txid:
+              type: string
+              description: 'The hash of the referenced, previous transaction'
+            vout:
+              type: integer
+              description: The index of the output to spent and used as input
+            scriptSig:
+              type: string
+              description: The hex-encoded signature script
+            sequence:
+              type: integer
+              description: Script sequence number
+            error:
+              type: string
+              description: Verification or signing error related to the input
+    signzelnodetransaction:
+      type: object
+      properties:
+        status:
+          type: string
+          description: Explanation of status
+        tier:
+          type: string
+          description: Tier of ZelNode
+        hex:
+          type: string
+          description: Hex encoded info of the transaction
+    startzelnode:
+      type: object
+      properties:
+        overall:
+          type: string
+          description: Overall status messge
+        detail:
+          type: array
+          items:
+            type: object
+            properties:
+              node:
+                type: string
+                description: Node name or alias
+              result:
+                type: string
+                description: Success or failed
+              error:
+                type: string
+                description: Error message if failed
+    vout:
+      type: array
+      items:
+        type: object
+        properties:
+          value:
+            type: number
+            description: The value in ZEL
+          valueZat:
+            type: integer
+            description: The value in ZEL
+          valueSat:
+            type: integer
+            description: The value in ZEL
+          'n':
+            type: integer
+            description: Index
+          scriptPubKey:
+            type: object
+            properties:
+              asm:
+                type: string
+                description: Script public key
+              hex:
+                type: string
+                description: The hex
+              reqSigs:
+                type: integer
+                description: The required sigs
+              type:
+                type: string
+                description: 'The type, eg pubkeyhash'
+              addresses:
+                type: array
+                items:
+                  type: string
+                  description: ZEL addresses
+    walletconflicts:
+      type: array
+      items:
+        type: object
+        description: If conflicts array of objects will return.
+    zelappsresources:
+      type: object
+      properties:
+        zelAppsCpusLocked:
+          type: number
+          description: Amount of cores app is using
+        zelAppsRamLocked:
+          type: integer
+          description: Amount of ram app is using
+        zelAppsHddLocked:
+          type: integer
+          description: Amount of disk space app is using
+    zelcashgetinfo:
+      type: object
+      properties:
+        version:
+          type: integer
+          description: The server version
+        protocolversion:
+          type: integer
+          description: The protocol version
+        walletversion:
+          type: integer
+          description: The wallet version
+        balance:
+          type: number
+          description: The total Zelcash balance of the wallet
+        blocks:
+          type: integer
+          description: The current number of blocks processed in the server
+        timeoffset:
+          type: integer
+          description: The time offset
+        connections:
+          type: integer
+          description: The number of connections
+        proxy:
+          type: string
+          description: The proxy used by the server
+        difficulty:
+          type: number
+          description: The current difficulty
+        testnet:
+          type: boolean
+          description: If the server is using testnet or not
+        keypoololdest:
+          type: integer
+          description: >-
+            The timestamp (seconds since GMT epoch) of the oldest pre-generated
+            key in the key pool
+        keypoolsize:
+          type: integer
+          description: How many new keys are pre-generated
+        paytxfee:
+          type: number
+          description: The transaction fee set at ZEL/kB
+        relayfee:
+          type: number
+          description: Minimum relay fee for non-free transactions in ZEL/kB
+        errors:
+          type: string
+          description: Any error messages
+    zelnodestatus:
+      type: object
+      properties:
+        status:
+          type: string
+          description: ZelNode status
+        collateral:
+          type: string
+          description: Collateral transaction
+        txhash:
+          type: string
+          description: Collateral transaction hash
+        outidx:
+          type: integer
+          description: Collateral transaction output index number
+        ip:
+          type: string
+          description: ZelNode network address
+        network:
+          type: string
+          description: 'Network type (IPv4, IPv6, onion)'
+        added_height:
+          type: integer
+          description: Block height when ZelNode was added
+        confirmed_height:
+          type: integer
+          description: Block height when ZelNode was confirmed
+        last_confirmed_height:
+          type: integer
+          description: Last block height when ZelNode was confirmed
+        last_paid_height:
+          type: integer
+          description: Last block height when ZelNode was paid
+        tier:
+          type: string
+          description: Tier (BASIC/SUPER/BAMF)
+        payment_address:
+          type: string
+          description: ZEL address for ZelNode payments
+        pubkey:
+          type: string
+          description: ZelNode public key used for message broadcasting
+        activesince:
+          type: integer
+          description: >-
+            The time in seconds since epoch (Jan 1 1970 GMT) ZelNode has been
+            active
+        lastpaid:
+          type: integer
+          description: >-
+            The time in seconds since epoch (Jan 1 1970 GMT) ZelNode was last
+            paid
+    zoperationstatus:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+            description: The operation id
+          status:
+            type: string
+            description: Explanation of status
+          creation_time:
+            type: integer
+            description: The time in seconds since epoch (Jan 1 1970 GMT)
+          result:
+            type: object
+            properties:
+              txid:
+                type: string
+                description: Transaction id
+          execution_secs:
+            type: number
+            description: Amount of time in seconds of operation
+          method:
+            type: string
+            description: The operation method
+          params:
+            type: object
+            properties:
+              fromaddress:
+                type: string
+                description: Address funds sent from
+              amounts:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    address:
+                      type: string
+                      description: Receiving address
+                    amount:
+                      type: number
+                      description: Sending amount
+          minconf:
+            type: integer
+            description: Amount of confirmations required
+          fee:
+            type: number
+            description: Fee amount used
+    containerinfo:
+      type: array
+      items:
+        type: object
+        properties:
+          Id:
+            type: string
+            description: ID of this container
+          Names:
+            type: array
+            items:
+              type: string
+              description: The names that this container has been given
+          Image:
+            type: string
+            description: The name of the image used when creating this container
+          ImageID:
+            type: string
+            description: The ID of the image that this container was created from
+          Command:
+            type: string
+            description: Command to run when starting the container
+          Created:
+            type: integer
+            description: When the container was created in epoch time
+          Ports:
+            type: array
+            items:
+              type: object
+              properties:
+                PrivatePort:
+                  type: integer
+                  description: Port on the container
+                Type:
+                  type: string
+                  enum:
+                    - tcp
+                    - udp
+                    - sctp
+                  description: 'tcp, udp, sctp'
+                IP:
+                  type: string
+                  description: Host IP address that the container's port is mapped to
+                PublicPort:
+                  type: integer
+                  description: Port exposed on the host
+                Labels:
+                  type: object
+                  description: User-defined key/value metadata
+                  properties:
+                    description:
+                      type: string
+                      description: Description of app
+                    maintainer:
+                      type: string
+                      description: Name/alias of creator/maintainer of app
+                    repository:
+                      type: string
+                      description: Url to repository
+                    version:
+                      type: number
+                      description: Version number
+                State:
+                  type: string
+                  description: State/status of the container
+                Status:
+                  type: string
+                  description: Additional human-readable status of this container
+                HostConfig:
+                  type: object
+                  properties:
+                    NetworkMode:
+                      type: string
+                      description: Network mode of container
+                NetworkSettings:
+                  type: object
+                  description: A summary of the container's network settings
+                  properties:
+                    Networks:
+                      type: object
+                      description: Configuration for a network endpoint.
+                      properties:
+                        zelfluxDockerNetwork:
+                          $ref: '#/components/schemas/zelfluxnetwork'
+                Mounts:
+                  $ref: '#/components/schemas/mounts'
+    mounts:
+      type: array
+      items:
+        type: object
+        properties:
+          Type:
+            type: string
+            enum:
+              - bind
+              - volume
+              - tmpfs
+              - npipe
+            description: Mount type
+          Source:
+            type: string
+            description: Path of dir to mount
+          Destination:
+            type: string
+            description: Dir of container to bind mount
+          Mode:
+            type: string
+            description: Bind mount mode
+          RW:
+            type: boolean
+            description: Whether the mount should be read-write
+          Propagation:
+            type: string
+            enum:
+              - private
+              - rprivate
+              - shared
+              - rshared
+              - slave
+              - rslave
+            description: >-
+              A propagation mode with the value [r]private, [r]shared, or
+              [r]slave.
+    zelfluxnetwork:
+      type: object
+      properties:
+        IPAMConfig:
+          type: string
+          description: EndpointIPAMConfig represents an endpoint's IPAM configuration
+        Links:
+          type: string
+          description: Links
+        Aliases:
+          type: string
+          description: Aliases
+        NetworkID:
+          type: string
+          description: Unique ID of the network
+        EndpointID:
+          type: string
+          description: Unique ID for the service endpoint in a Sandbox
+        Gateway:
+          type: string
+          description: Gateway address for this network
+        IPAddress:
+          type: string
+          description: IPv4 address
+        IPPrefixLen:
+          type: string
+          description: Mask length of the IPv4 address
+        IPv6Gateway:
+          type: string
+          description: IPv6 gateway address
+        GlobalIPv6Address:
+          type: string
+          description: Global IPv6 address
+        GlobalIPv6PrefixLen:
+          type: string
+          description: Mask length of the global IPv6 address
+        MacAddress:
+          type: string
+          description: MAC address for the endpoint on this network
+        DriverOpts:
+          type: string
+          description: >-
+            DriverOpts is a mapping of driver options and values. These options
+            are passed directly to the driver and are driver specific.
   headers:
     zelidauth:
       description: ZelID authentication header
       schema:
         type: string
-  # Security scheme definitions that can be used across the specification.
   securitySchemes:
-    ZelID: # security definition name (you can name it as you want)
-      description: Zel ID is an authentication system based on Bitcoin message signing. zelidauth header consist of stringified query of zelid, signature, loginPhrase Please refer to Authentication workflow section on how to obtain correct zelidauth header. An example of a header is `zelid=1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC&signature=H%2BZB3oSrsw6XkBxxlbwk33LEBJYvqtbMIm2kL9JzuoXMC6pSZd0lBHdnhJYzMTXv81zZQ7G%2FpkK1NvYN7cNF0GE%3D&loginPhrase=1574991374806spbcvsuwerl52tppx9dw5khuz8rew13mkq86gg8r2c`
+    ZelID:
+      description: >-
+        Zel ID is an authentication system based on Bitcoin message signing.
+        zelidauth header consist of stringified query of zelid, signature,
+        loginPhrase Please refer to Authentication workflow section on how to
+        obtain correct zelidauth header. An example of a header is
+        `zelid=1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC&signature=%2BZB3oSrsw6XkBxxlbwk33LEBJYvqtbMIm2kL9JzuoXMC6pSZd0lBHdnhJYzMTXv81zZQ7G%2FpkK1NvYN7cNF0GE%3D&loginPhrase=1574991374806spbcvsuwerl52tppx9dw5khuz8rew13mkq86gg8r2c`
       type: apiKey
-      in: header # Where API key will be passed: header or query
-      name: zelidauth # API key parameter name
-    
+      in: header
+      name: zelidauth


### PR DESCRIPTION
### Notes/To do's:
- [x] Both `POST and GET /zelflux/broadcastmessage` need to be looked at. Not sure what the request body should look like nor what should be in the `?data=xxxx` parameter. Left media type as `text/plain` and data as a `string`. May want to also change the example. Left a hex-encoded in the example commented out that will decode to HelloWorld although I am pretty sure that is not the type of data messages to be sent. Description should also be changed as I have left it as `The message` as I don't know what data should contain in the message.
- [x] Same as above with `POST and GET /zelflux/broadcastmessagetooutgoing` and `POST and GET /zelflux/broadcastmessagetoincoming`
- [x] A better description for `GET /zelid/emergencyphrase` as I am not sure in what scenerio this would be used.
- [x] Did not document both `POST and GET /zelcash/submitblock` as not sure what hex-encoded data should be in the parameter.
- [x] Check both `POST and GET /zelcash/createmultisig` permissions level as it is set to **PUBLIC** at the moment but seems it should be at the **ADMIN** level. Don't think you could create a multisig without knowing if the keypool of the node has the public key/keys of the addresses and only the ADMIN should know this info. If you try to use an address that don't belong to the node it will return with an error.
- [x] Did not document `GET /zelapps/zelappregister` and `GET /zelapps/zelapppull` not sure if it's functional. Also `GET zelapps/zelappexec` as I came across errors since I am not sure what to test with in the `cmd` and `env` arrays.
- [x] Did not document `GET /zelcash/zmergetoaddress` as I couldn't get it to work.
- [x] Correct spelling of the word `successfully` as of now it stands as `succesfully` on response message of `zelappstart, ...stop, ...restart, ...kill, ...containerremove, ...pause, ...unpause, ...remove, ...imageremove`
- [x] Check description for `GET /zelflux/dosstate`
- [x] Check if format is set right for `GET zelapps/zelshare/getfile`
- [ ] Check `jsonrequestobject` parameter example for `GET /zelcash/getblocktemplate` call and make changes if not correct
- [ ] Both `POST and GET /zelcash/sendmany` needs to be looked at as I wasn't able to make the `subtractfeefrom` parameter work as an `array` but seems to work as a `boolean`. Please check in case I am wrong. Left description for array commented out to make it easier to make changes if needed and remember to delete commented description if boolean method is correct.
- [x] Add to available values of the `benchmarktype` parameter in the `/zelcash/zcbenchmark` call. Only listed ones I was able to get a successful response.
- [ ] List objects for `walletconflicts` in components section as I couldn't get figure out what the objects were if it did return one in the case of conflicts
- [ ] Possibly give reference credit to https://docs.docker.com/engine/api/v1.40/ as most of the descriptions for `/zelapps` calls are from their docs.

**_Did not document any error responses_**
### Deprecated/useless calls that was not documented:
- `GET /zelcash/znsync`
- `GET /zelcash/decodezelnodebroadcast`
- `GET /zelcash/getzelnodescores`
- `GET /zelcash/getzelnodewinners`
- `GET /zelcash/relayzelnodebroadcast`
- `GET /zelcash/createzelnodebroadcast`
- `GET /zelcash/zelnodedebug`
- `POST and GET /zelcash/sendfrom`
- `POST and GET /zelcash/zcrawjoinsplit`
- `POST and GET /zelcash/zcrawreceive`
- `GET /zelcash/zcrawkeygen`
- `GET /zelcash/zcsamplejoinsplit`
### Duplicate operationId's to check:
- `/zelcash/getbenchmarks` `zelbench/getbenchmarks`
- `/zelcash/reindexzelcash` `zelnode/reindexzelcash`
- `/zelcash/start` `/zelnode/startzelcash`
- `/zelcash/restart` `/zelnode/restartzelcash`
- `/zelcash/stop` `/zelbench/stop` (these don't do the same)